### PR TITLE
Fixes various issues marked as critical

### DIFF
--- a/client/src/components/General/RichTextEditor.css
+++ b/client/src/components/General/RichTextEditor.css
@@ -6,3 +6,7 @@
 .simple-text-border {
   border: 1px solid #ced4da;
 }
+
+.ql-editor {
+  white-space: break-spaces;
+}

--- a/client/src/components/General/RichTextEditor.js
+++ b/client/src/components/General/RichTextEditor.js
@@ -38,6 +38,7 @@ function RichTextEditor(props) {
   return (
     <div className={`text-editor ${props.showToolbar() ? "" : "simple-text-border"}`}>
       <ReactQuill
+        preserveWhitespace={true}
         value={props.value}
         onChange={(text) => props.onChange(text)}
         id={`quill-${props.id}`}

--- a/client/src/pages/ContentPage/Card/Source.js
+++ b/client/src/pages/ContentPage/Card/Source.js
@@ -11,6 +11,12 @@ function Source (props) {
     if (props.source > 0) {
       window.$('[data-bs-toggle="popover"]').popover();
     }
+
+    // On unmount: clean up all popover instances (if any)
+    return () => {
+      window.$('[data-bs-toggle="popover"]').popover('dispose');
+    };
+    
   }, [props.source]);
 
   return props.source > 0 ? (

--- a/client/src/pages/ContentPage/Card/Source.js
+++ b/client/src/pages/ContentPage/Card/Source.js
@@ -2,25 +2,15 @@ import React, {useEffect} from "react";
 import PropTypes from "prop-types";
 import DOMPurify from "dompurify";
 import "./Source.css";
+import { Popover } from "bootstrap";
 
 // Represents an inline citation that links to the reference card
 function Source (props) {
 
   useEffect(() => {
-    let popoverList = [];
     if (props.source > 0) {
-      const popoverTriggerList = document.querySelectorAll('[data-bs-toggle="popover"]');
-      popoverList = [...popoverTriggerList].map(popoverTriggerEl => {
-        return bootstrap.Popover.getOrCreateInstance(popoverTriggerEl);
-      });
+      window.$('[data-bs-toggle="popover"]').popover();
     }
-
-    // On unmount: clean up all popover instances (if any)
-    return () => {
-      popoverList.forEach(popoverInstance => {
-        popoverInstance.dispose();
-      });
-    };
   }, [props.source]);
 
   return props.source > 0 ? (

--- a/client/src/pages/ContentPage/Card/Source.js
+++ b/client/src/pages/ContentPage/Card/Source.js
@@ -2,7 +2,6 @@ import React, {useEffect} from "react";
 import PropTypes from "prop-types";
 import DOMPurify from "dompurify";
 import "./Source.css";
-import { Popover } from "bootstrap";
 
 // Represents an inline citation that links to the reference card
 function Source (props) {


### PR DESCRIPTION
Fixes #82, #84

This PR:
- Fixes various pages crashing due to an incomplete bootstrap 5 migration. Reverted a small popover migration back to bs4 to fix error, will complete the bs5 migration later on during package upgrade work. 
- Fixes card creation text field issue by adding whitespace preservation to the ReactQuill HTML entry box in the card creation modal.