### PR TITLE
fix: adds integrity and cors attributes to scripts

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -21,7 +21,6 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
     integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
     crossorigin="anonymous"></script>
-  <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet" crossorigin="anonymous">
 
   <!-- Latest compiled and minified CSS -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css"
@@ -77,4 +76,3 @@
   <script src="/checkBrowser.js"></script>
 </body>
 </html>
-

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -6,7 +6,7 @@
   <meta http-equiv="content-language" content="en" />
 
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-  <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet" crossorigin="anonymous">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
     integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
@@ -21,13 +21,17 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"
     integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM"
     crossorigin="anonymous"></script>
-  <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet" crossorigin="anonymous">
 
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css"
+    integrity="sha384-YT6Vh7LpL+LTEi0RVF6MlYgTcoBIji2PmGBbXk3D4So5lw1e64pyuwTtbLOED1Li"
+    crossorigin="anonymous">
 
   <!-- Latest compiled and minified JavaScript -->
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"
+    integrity="sha384-V2ETvVMpY0zaj0P3nwnqTUqHU19jQInctJYWqgEQE/5vFaU3fWdcMfufqV/8ISD7"
+    crossorigin="anonymous"></script>
 
   <script
     type="text/javascript"> (function () { var css = document.createElement('link'); css.href = 'https://use.fontawesome.com/releases/v5.1.0/css/all.css'; css.rel = 'stylesheet'; css.type = 'text/css'; document.getElementsByTagName('head')[0].appendChild(css); })(); </script>
@@ -57,7 +61,9 @@
 <body>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-filestyle/2.1.0/bootstrap-filestyle.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-filestyle/2.1.0/bootstrap-filestyle.min.js"
+    integrity="sha384-GbPmiumnh/HQAV2JgGcmVpE0tindFBG0TeGqdo6sSyS25E3RFQRU7JVTT3i+Ddy8"
+    crossorigin="anonymous"></script>
   <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
@@ -71,3 +77,4 @@
   <script src="/checkBrowser.js"></script>
 </body>
 </html>
+


### PR DESCRIPTION
Fixes #74.

Integrity hashes were generated by running this command:
curl -s https://served-content-url.[js/css] | \
openssl dgst -sha384 -binary | openssl base64 -A

Only jsdelivr served content needs integrity attributes. Google Fonts are dynamically generated CSS (not a fixed file) and can change over time without versioned file integrity guarantees, so hashes would break often.