### PR TITLE
feat: allows graphics' contentLabel and alt text to be different

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -43,6 +43,46 @@ The default configuration runs in **development mode** with hot reload enabled.
 
 > **⚠️ Security Note:** Create your own secure passwords in the `secrets/` directory. See the [README.md](README.md#user-secrets) for setup instructions. **Never commit real credentials to source control.**
 
+### Manual DB migration for alt text (Docker)
+
+If your Docker database volume was created before `altText` was added to `Items` and
+`History_Items`, run the migration once while the stack is up. The init SQL in
+`docker-compose.yml` only runs on **first** database container startup; existing
+`db_data` volumes are not altered automatically.
+
+Migration script: `services/database/manual-migration-add-altText-to-items.sql`
+
+The script is idempotent and skips columns that already exist.
+
+**Option 1 — pipe SQL into the database container (recommended)**
+
+From the repository root, with `docker compose up -d` running:
+
+```bash
+# Linux, macOS, Git Bash, or WSL
+cat services/database/manual-migration-add-altText-to-items.sql | docker compose exec -T database mysql -u root -p"$(cat secrets/mysql_root_password.txt)" eec_walkthrough
+```
+
+```powershell
+# Windows PowerShell
+Get-Content services\database\manual-migration-add-altText-to-items.sql -Raw | docker compose exec -T database mysql -u root -p((Get-Content secrets\mysql_root_password.txt -Raw).Trim()) eec_walkthrough
+```
+
+Replace `eec_walkthrough` with your `MYSQL_DB_NAME` from `.env` if it differs.
+
+**Option 2 — phpMyAdmin**
+
+1. Open http://localhost:8080 and log in (use credentials from `secrets/`).
+2. Select the `eec_walkthrough` database (or your `MYSQL_DB_NAME`).
+3. Open the **Import** tab.
+4. Choose `services/database/manual-migration-add-altText-to-items.sql` from this repo.
+5. Click **Go**.
+
+**Verify**
+
+In phpMyAdmin or the MySQL client, confirm `Items` and `History_Items` each have an
+`altText` column (`varchar(1000)`, default `''`).
+
 ## Services
 
 ### Database (MariaDB 10.11)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,17 @@ Run the following command to start the server in development mode. Your applicat
 npm run dev
 ```
 
+### Manual DB migration for alt text
+
+If your database was created before `altText` was added to `Items` and `History_Items`,
+run this migration script once against your DB:
+
+```
+mysql -u <user> -p <database_name> < services/database/manual-migration-add-altText-to-items.sql
+```
+
+The script is idempotent and will skip columns that already exist.
+
 
 ## Update the Production Server
 

--- a/client/src/components/General/Image.js
+++ b/client/src/components/General/Image.js
@@ -8,13 +8,16 @@ import "./Image.css";
 function Image(props) {
   const [modalShow, setModalShow] = useState(false);
   const [title] = useState(props.title.replace(/<\/?[^>]+(>|$)/g, ""));
+  const altAttr = props.altText && props.altText.trim() ? props.altText.trim() : title;
 
+  console.log("altAttr being set by Image", altAttr);
+  
   if (props.thumbnail) {
     return (
       <Col className="px-0">
         <img
           src={props.url}
-          alt={title}
+          alt={altAttr}
           title={title}
           onError={(e) => e.target.src = "/missing.png"}
           className="expandable-image rounded img-fluid img-thumbnail"
@@ -33,7 +36,7 @@ function Image(props) {
       <Col className="px-0">
         <img
           src={props.url}
-          alt={title}
+          alt={altAttr}
           onError={(e) => e.target.src = "/missing.png"}
           className="expandable-image header rounded img-fluid img-normal"
           onClick={() => setModalShow(true)}
@@ -51,7 +54,7 @@ function Image(props) {
       <Fragment>
         <img
           src={props.url}
-          alt={title}
+          alt={altAttr}
           onError={(e) => e.target.src = "/missing.png"}
           className="expandable-image rounded img-fluid"
           style={{cursor: "pointer", maxWidth: "15em"}}
@@ -72,6 +75,7 @@ export default Image;
 Image.propTypes = {
   url: PropTypes.string.isRequired,
   title: PropTypes.string,
+  altText: PropTypes.string,
   thumbnail: PropTypes.bool,
   header: PropTypes.bool
 };

--- a/client/src/components/General/Image.js
+++ b/client/src/components/General/Image.js
@@ -7,11 +7,9 @@ import "./Image.css";
 // Displays various kinds of images
 function Image(props) {
   const [modalShow, setModalShow] = useState(false);
-  const [title] = useState(props.title.replace(/<\/?[^>]+(>|$)/g, ""));
+  const title = (props.title || "").replace(/<\/?[^>]+(>|$)/g, "");
   const altAttr = props.altText && props.altText.trim() ? props.altText.trim() : title;
 
-  console.log("altAttr being set by Image", altAttr);
-  
   if (props.thumbnail) {
     return (
       <Col className="px-0">

--- a/client/src/pages/ContentPage/Card/BasicItems.js
+++ b/client/src/pages/ContentPage/Card/BasicItems.js
@@ -190,6 +190,7 @@ function BasicItems(props) {
                     color={item.color}
                     text={item.contentText}
                     label={item.contentLabel}
+                    altText={item.altText || ""}
                     contentMode={item.contentMode}
                     created={item.created}
                     indentation={item.indentation}
@@ -229,6 +230,7 @@ function BasicItems(props) {
                 color={item.color}
                 text={item.contentText}
                 label={item.contentLabel}
+                altText={item.altText || ""}
                 contentMode={item.contentMode}
                 created={item.created}
                 indentation={item.indentation}

--- a/client/src/pages/ContentPage/Card/BulletPoint.js
+++ b/client/src/pages/ContentPage/Card/BulletPoint.js
@@ -105,6 +105,7 @@ function BulletPoint(props) {
           <BulletPointGraphic
             text={props.text}
             label={props.label}
+            altText={props.altText}
             url={props.url}
             icon={props.icon}
             indentation={props.indentation}
@@ -230,6 +231,7 @@ function BulletPoint(props) {
           <BulletPointGraphic
             text={props.text}
             label={props.label}
+            altText={props.altText}
             url={props.url}
             icon={props.icon}
             indentation={props.indentation}
@@ -312,6 +314,7 @@ BulletPoint.propTypes = {
   id: PropTypes.number,
   text: PropTypes.string,
   label: PropTypes.string,
+  altText: PropTypes.string,
   url: PropTypes.string,
   learnMoreUrl: PropTypes.string,
   icon: PropTypes.string,

--- a/client/src/pages/ContentPage/Card/BulletPointGraphic.js
+++ b/client/src/pages/ContentPage/Card/BulletPointGraphic.js
@@ -62,6 +62,7 @@ function BulletPointGraphic(props) {
           <Image
             url={props.url}
             title={props.label}
+            altText={props.altText}
             thumbnail={false}
             header={largeImage()}
           />
@@ -78,6 +79,7 @@ export default BulletPointGraphic;
 BulletPointGraphic.propTypes = {
   text: PropTypes.string,
   label: PropTypes.string,
+  altText: PropTypes.string,
   url: PropTypes.string,
   icon: PropTypes.string,
   indentation: PropTypes.number,

--- a/client/src/pages/ContentPage/Card/ConstructCardModal.js
+++ b/client/src/pages/ContentPage/Card/ConstructCardModal.js
@@ -95,6 +95,7 @@ function ConstructCardModal(props) {
       itemData.contentLabel = item.contentLabel;
       itemData.contentUrl = item.contentUrl;
       itemData.learnMoreUrl = item.learnMoreUrl;
+      itemData.altText = item.altText || "";
       itemData.indentation = item.indentation;
       itemData.iconType = item.iconType;
       itemData.contentMode = item.contentMode;
@@ -249,6 +250,7 @@ function ConstructCardModal(props) {
     copy[key].contentLabel = "";
     copy[key].contentUrl = "";
     copy[key].learnMoreUrl = "";
+    copy[key].altText = "";
     copy[key].iconType = newIconType;
     copy[key].groupIndex = groupIndex;
     copy[key].contentMode = newContentMode;
@@ -1017,6 +1019,9 @@ function ConstructCardModal(props) {
       copy[key].contentLabel = e.target.value;
     } else if (groupIndex === 6) {
       copy[key].learnMoreUrl = e.target.value;
+    } else if (groupIndex === 7) {
+      console.log("altText being set by ConstructCardModal", e.target.value);
+      copy[key].altText = e.target.value;
     }
     setItems(copy);
   }
@@ -1113,7 +1118,7 @@ function ConstructCardModal(props) {
       itemString += item.contentText + "$%$" + item.contentLabel + "$%$" +
         item.contentUrl + "$%$" + item.iconType + "$%$" + item.groupIndex + "$%$" +
         item.contentMode + "$%$" + item.internal + "$%$" + item.sourceId + "$%$" +
-        item.inline + "$%$" + item.learnMoreUrl;
+        item.inline + "$%$" + item.learnMoreUrl + "$%$" + (item.altText || "");
     }
 
     // show the toast stating that we have copied an item
@@ -1160,6 +1165,7 @@ function ConstructCardModal(props) {
       copy[key].inline = parseInt(itemArray[8], 10);
       copy[key].indentation = 0;
       copy[key].learnMoreUrl = itemArray[9];
+      copy[key].altText = itemArray[10] || "";
 
       // Make sure the indentation is up to date
       copy = scanIndentation(copy);

--- a/client/src/pages/ContentPage/Card/ConstructCardModal.js
+++ b/client/src/pages/ContentPage/Card/ConstructCardModal.js
@@ -1020,7 +1020,6 @@ function ConstructCardModal(props) {
     } else if (groupIndex === 6) {
       copy[key].learnMoreUrl = e.target.value;
     } else if (groupIndex === 7) {
-      console.log("altText being set by ConstructCardModal", e.target.value);
       copy[key].altText = e.target.value;
     }
     setItems(copy);

--- a/client/src/pages/ContentPage/Card/ConstructCardModal.js
+++ b/client/src/pages/ContentPage/Card/ConstructCardModal.js
@@ -1071,6 +1071,7 @@ function ConstructCardModal(props) {
         }
       }
     }
+
     return null;
   }
 

--- a/client/src/pages/ContentPage/Card/IconDropdown.js
+++ b/client/src/pages/ContentPage/Card/IconDropdown.js
@@ -7,6 +7,11 @@ import "./IconDropdown.css";
 function IconDropdown(props) {
 
   const [selectedIcon, setSelectedIcon] = useState(props.iconIndex);
+  const hasValidSelectedIcon = (
+    typeof selectedIcon === "number" &&
+    selectedIcon >= 0 &&
+    selectedIcon < props.icons.length
+  );
 
   // update the selected icon
   useEffect(() => {
@@ -23,7 +28,7 @@ function IconDropdown(props) {
     <Fragment >
       <Dropdown className="icon-drop-down-menu">
         <Dropdown.Toggle variant="outline-dark" id="dropdown-basic">
-          {selectedIcon === null ? (
+          {!hasValidSelectedIcon ? (
             "Icon"
           ) : (
             <i

--- a/client/src/pages/ContentPage/Card/ItemInput.js
+++ b/client/src/pages/ContentPage/Card/ItemInput.js
@@ -162,6 +162,16 @@ function ItemInput(props) {
               onNewImage={(newImage) => props.onNewImage(newImage, props.index)}
               default={"Upload an Image"}
             />
+            <FormControl
+              as="textarea"
+              rows="1"
+              maxLength="1000"
+              className={`${props.internal ? "internal-modal-item" : ""} ${props.inline ? "inline-modal-item" : ""}`}
+              placeholder="Alt text (accessibility description, uses the image caption if left blank)"
+              value={props.value.altText}
+              aria-label="Image alt text"
+              onChange={(e) => props.handleInput(e, props.index, 7)}
+            />
           </div>
           <Dropdown className="source-select-drop-down-menu ml-2">
             <Dropdown.Toggle variant="outline-dark">

--- a/client/src/pages/ContentPage/Card/ThumbnailGallery.js
+++ b/client/src/pages/ContentPage/Card/ThumbnailGallery.js
@@ -112,6 +112,7 @@ function ThumbnailGallery(props) {
             <Image
               url={item.contentUrl}
               title={item.contentLabel}
+              altText={item.altText}
               thumbnail={true}
               header={false}
             />
@@ -131,6 +132,7 @@ function ThumbnailGallery(props) {
             <Image
               url={item.contentUrl}
               title={item.contentLabel}
+              altText={item.altText}
               thumbnail={true}
               header={false}
             />

--- a/models/cards.js
+++ b/models/cards.js
@@ -210,13 +210,13 @@ async function deleteCard(cardId) {
         const sqlArray = [newHistoryId, results[0][i].itemId, results[0][i].cardId,
           results[0][i].orderIndex, results[0][i].indentation, results[0][i].iconType,
           results[0][i].contentText, results[0][i].contentUrl, results[0][i].contentLabel,
-          results[0][i].contentMode, results[0][i].internal, results[0][i].inline,
+          results[0][i].altText, results[0][i].contentMode, results[0][i].internal, results[0][i].inline,
           results[0][i].created, results[0][i].sourceId];
 
         sql = "INSERT INTO History_Items " +
 					"(parentId, itemId, cardId, orderIndex, indentation, iconType, contentText, " +
-					"contentUrl, contentLabel, contentMode, internal, inline, created, sourceId) " +
-					"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
+					"contentUrl, contentLabel, altText, contentMode, internal, inline, created, sourceId) " +
+					"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
 
         await pool.query(sql, sqlArray);
       }
@@ -605,12 +605,12 @@ async function publishCard(cardId) {
       const sqlArray = [newHistoryId, results[0][i].itemId, results[0][i].cardId,
         results[0][i].orderIndex, results[0][i].indentation, results[0][i].iconType,
         results[0][i].contentText, results[0][i].contentUrl, results[0][i].contentLabel,
-        results[0][i].contentMode, results[0][i].internal, results[0][i].inline, results[0][i].created, results[0][i].sourceId];
+        results[0][i].altText, results[0][i].contentMode, results[0][i].internal, results[0][i].inline, results[0][i].created, results[0][i].sourceId];
 
       sql = "INSERT INTO History_Items " +
 				"(parentId, itemId, cardId, orderIndex, indentation, iconType, contentText, " +
-				"contentUrl, contentLabel, contentMode, internal, inline, created, sourceId) " +
-				"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
+				"contentUrl, contentLabel, altText, contentMode, internal, inline, created, sourceId) " +
+				"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);";
 
       await pool.query(sql, sqlArray);
     }

--- a/models/cards.js
+++ b/models/cards.js
@@ -44,6 +44,7 @@ async function createCard(headerId, cardType, title, items, userId) {
         inline,
         sourceId,
         learnMoreUrl,
+        altText,
       } = item;
 
       if (
@@ -56,7 +57,8 @@ async function createCard(headerId, cardType, title, items, userId) {
         typeof internal !== "number" ||
         typeof inline !== "number" ||
         typeof sourceId !== "number" ||
-        typeof learnMoreUrl !== "string"
+        typeof learnMoreUrl !== "string" ||
+        typeof altText !== "string"
       ) {
         return { error: 3 };
       }
@@ -110,7 +112,7 @@ async function createCard(headerId, cardType, title, items, userId) {
     let itemsSql = `INSERT INTO Items (
       cardId, orderIndex, indentation, iconType, contentText,
       contentUrl, contentLabel, contentMode,
-      internal, inline, sourceId, learnMoreUrl, approved
+      internal, inline, sourceId, learnMoreUrl, altText, approved
     ) VALUES `;
 
     for (const item of items) {
@@ -127,7 +129,7 @@ async function createCard(headerId, cardType, title, items, userId) {
         learnMoreUrl: item.learnMoreUrl
       });
       
-      itemsSql += `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0),`;
+      itemsSql += `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0),`;
       sqlParams.push(
         cardId,
         items.indexOf(item),
@@ -140,7 +142,8 @@ async function createCard(headerId, cardType, title, items, userId) {
         item.internal,
         item.inline,
         item.sourceId,
-        item.learnMoreUrl
+        item.learnMoreUrl,
+        item.altText
       );
     }
 
@@ -371,6 +374,8 @@ async function updateCard(cardId, cardType, title, items, userId) {
         return {error: 2};
       } else if (typeof items[i].learnMoreUrl !== "string") {
         return {error: 2};
+      } else if (typeof items[i].altText !== "string") {
+        return {error: 2};
       }
 
       // see if we have a non-image item
@@ -427,11 +432,11 @@ async function updateCard(cardId, cardType, title, items, userId) {
 
         // create all of the new items
         sql = "INSERT INTO Items (cardId, orderIndex, indentation, iconType, " +
-					"contentText, contentUrl, contentLabel, contentMode, internal, inline, sourceId, learnMoreUrl, approved) VALUES ";
+				"contentText, contentUrl, contentLabel, contentMode, internal, inline, sourceId, learnMoreUrl, altText, approved) VALUES ";
 
         // expand the sql string and array based on the number of items
         items.forEach((currentValue, index) => {
-          sql += "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0),";
+          sql += "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0),";
           sqlArray.push(cardId);
           sqlArray.push(typeof currentValue.orderIndex === "number" ? currentValue.orderIndex : index);
           sqlArray.push(currentValue.indentation);
@@ -444,6 +449,7 @@ async function updateCard(cardId, cardType, title, items, userId) {
           sqlArray.push(currentValue.inline);
           sqlArray.push(currentValue.sourceId);
           sqlArray.push(currentValue.learnMoreUrl);
+          sqlArray.push(currentValue.altText);
         });
 
         // replace the final comma with a semicolon

--- a/models/cards.js
+++ b/models/cards.js
@@ -117,19 +117,6 @@ async function createCard(headerId, cardType, title, items, userId) {
     ) VALUES `;
 
     for (const item of items) {
-      console.log("Processing item:", {
-        indentation: item.indentation,
-        iconType: item.iconType,
-        contentText: item.contentText?.substring(0, 50) + "...",
-        contentUrl: item.contentUrl,
-        contentLabel: item.contentLabel,
-        contentMode: item.contentMode,
-        internal: item.internal,
-        inline: item.inline,
-        sourceId: item.sourceId,
-        learnMoreUrl: item.learnMoreUrl
-      });
-      
       itemsSql += `(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0),`;
       sqlParams.push(
         cardId,

--- a/models/cards.js
+++ b/models/cards.js
@@ -73,8 +73,9 @@ async function createCard(headerId, cardType, title, items, userId) {
         return { error: 5 };
       }
 
-      // Check if any item is not an image
-      if (contentText !== "" || !contentUrl.length || !contentLabel.length) {
+      // Check if any item is not an image.
+      // A graphic requires empty contentText and a non-empty contentUrl.
+      if (contentText !== "" || !contentUrl.length) {
         notImage = true;
       }
     }
@@ -378,8 +379,8 @@ async function updateCard(cardId, cardType, title, items, userId) {
         return {error: 2};
       }
 
-      // see if we have a non-image item
-      if (items[i].contentText !== "" || !items[i].contentUrl.length || !items[i].contentLabel.length) {
+      // see if we have a non-image item.
+      if (items[i].contentText !== "" || !items[i].contentUrl.length) {
         notImage = true;
       }
     }

--- a/models/cards.js
+++ b/models/cards.js
@@ -58,7 +58,7 @@ async function createCard(headerId, cardType, title, items, userId) {
         typeof inline !== "number" ||
         typeof sourceId !== "number" ||
         typeof learnMoreUrl !== "string" ||
-        typeof altText !== "string"
+        (altText !== undefined && typeof altText !== "string")
       ) {
         return { error: 3 };
       }

--- a/models/pages.js
+++ b/models/pages.js
@@ -967,7 +967,7 @@ async function getReport(start, end, condense, offset) {
       if (allCardArray[i].oldVersion) {
         sql = "SELECT DISTINCT itemId, cardId, indentation, orderIndex, " +
         "HI.iconType, typeName, typeKeyword, contentText, " +
-        "contentUrl, contentLabel, contentMode, internal, " +
+        "contentUrl, contentLabel, altText, contentMode, internal, " +
         "created, color, sourceId, inline, groupIndex " +
         "FROM History_Items AS HI " +
         "LEFT JOIN Icons on HI.iconType = Icons.iconType " +
@@ -990,7 +990,7 @@ async function getReport(start, end, condense, offset) {
 
       sql = "SELECT DISTINCT itemId, cardId, indentation, orderIndex, " +
       "HI.iconType, typeName, typeKeyword, contentText, " +
-      "contentUrl, contentLabel, contentMode, internal, " +
+      "contentUrl, contentLabel, altText, contentMode, internal, " +
       "created, color, sourceId, inline, groupIndex " +
       "FROM History_Items AS HI " +
       "LEFT JOIN Icons on HI.iconType = Icons.iconType " +

--- a/models/pages.js
+++ b/models/pages.js
@@ -149,7 +149,7 @@ async function getFullPage(pageId, userId) {
           // get all approved items
           sql = "SELECT DISTINCT itemId, cardId, indentation, orderIndex, " +
           "Items.iconType, typeName, typeKeyword, contentText, " +
-          "contentUrl, contentLabel, contentMode, internal, " +
+          "contentUrl, contentLabel, altText, contentMode, internal, " +
           "created, approved, color, sourceId, inline, groupIndex, learnMoreUrl " +
           "FROM Items " +
           "LEFT JOIN Icons on Items.iconType = Icons.iconType " +
@@ -164,7 +164,7 @@ async function getFullPage(pageId, userId) {
           // get all unapproved items
           sql = "SELECT DISTINCT itemId, cardId, indentation, orderIndex, " +
           "Items.iconType, typeName, typeKeyword, contentText, " +
-          "contentUrl, contentLabel, contentMode, internal, " +
+          "contentUrl, contentLabel, altText, contentMode, internal, " +
           "created, approved, color, sourceId, inline, groupIndex, learnMoreUrl " +
           "FROM Items " +
           "LEFT JOIN Icons on Items.iconType = Icons.iconType " +
@@ -181,7 +181,7 @@ async function getFullPage(pageId, userId) {
           // get all approved items
           sql = "SELECT DISTINCT itemId, cardId, indentation, orderIndex, " +
           "Items.iconType, typeName, typeKeyword, contentText, " +
-          "contentUrl, contentLabel, contentMode, internal, " +
+          "contentUrl, contentLabel, altText, contentMode, internal, " +
           "created, approved, color, sourceId, inline, groupIndex " +
           "FROM Items " +
           "LEFT JOIN Icons on Items.iconType = Icons.iconType " +
@@ -197,7 +197,7 @@ async function getFullPage(pageId, userId) {
           // get all unapproved items
           sql = "SELECT DISTINCT itemId, cardId, indentation, orderIndex, " +
           "Items.iconType, typeName, typeKeyword, contentText, " +
-          "contentUrl, contentLabel, contentMode, internal, " +
+          "contentUrl, contentLabel, altText, contentMode, internal, " +
           "created, approved, color, sourceId, inline, groupIndex " +
           "FROM Items " +
           "LEFT JOIN Icons on Items.iconType = Icons.iconType " +
@@ -214,7 +214,7 @@ async function getFullPage(pageId, userId) {
 
           sql = "SELECT DISTINCT itemId, cardId, indentation, orderIndex, " +
           "Items.iconType, typeName, typeKeyword, contentText, " +
-          "contentUrl, contentLabel, contentMode, " +
+          "contentUrl, contentLabel, altText, contentMode, " +
           "created, approved, color, sourceId, inline, groupIndex " +
           "FROM Items " +
           "LEFT JOIN Icons on Items.iconType = Icons.iconType " +

--- a/services/database/db-init-new.sql
+++ b/services/database/db-init-new.sql
@@ -1159,6 +1159,7 @@ CREATE TABLE `History_Items` (
   `contentText` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `contentUrl` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `contentLabel` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `altText` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `contentMode` int(10) UNSIGNED NOT NULL,
   `internal` tinyint(3) UNSIGNED NOT NULL,
   `inline` tinyint(3) UNSIGNED NOT NULL,
@@ -3708,7 +3709,7 @@ CREATE TABLE `Items` (
   `created` timestamp NULL DEFAULT current_timestamp(),
   `approved` tinyint(3) UNSIGNED NOT NULL,
   `learnMoreUrl` varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `altText` varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''
+  `altText` varchar(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/services/database/db-init-new.sql
+++ b/services/database/db-init-new.sql
@@ -3707,7 +3707,8 @@ CREATE TABLE `Items` (
   `sourceId` int(10) UNSIGNED NOT NULL,
   `created` timestamp NULL DEFAULT current_timestamp(),
   `approved` tinyint(3) UNSIGNED NOT NULL,
-  `learnMoreUrl` varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL
+  `learnMoreUrl` varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `altText` varchar(1000) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT ''
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/services/database/manual-migration-add-altText-to-items.sql
+++ b/services/database/manual-migration-add-altText-to-items.sql
@@ -26,6 +26,25 @@ PREPARE stmt_items FROM @sql_items;
 EXECUTE stmt_items;
 DEALLOCATE PREPARE stmt_items;
 
+-- Backfill Items.altText from contentLabel for image URLs only.
+-- Rules:
+-- - contentUrl starts with /uploads/
+--   OR starts with http and ends with an image extension
+-- - contentLabel is non-empty
+-- - altText is currently empty
+UPDATE `Items`
+SET `altText` = `contentLabel`
+WHERE
+  (
+    `contentUrl` LIKE '/uploads/%'
+    OR (
+      LOWER(`contentUrl`) LIKE 'http%'
+      AND LOWER(`contentUrl`) REGEXP '\\.(png|jpe?g|gif|webp|bmp|svg|avif|tiff?|ico)$'
+    )
+  )
+  AND TRIM(COALESCE(`contentLabel`, '')) <> ''
+  AND TRIM(COALESCE(`altText`, '')) = '';
+
 -- Add History_Items.altText only if it does not exist
 SET @history_items_alt_exists := (
   SELECT COUNT(*)
@@ -44,5 +63,24 @@ SET @sql_history_items := IF(
 PREPARE stmt_history_items FROM @sql_history_items;
 EXECUTE stmt_history_items;
 DEALLOCATE PREPARE stmt_history_items;
+
+-- Backfill History_Items.altText from contentLabel for image URLs only.
+-- Rules:
+-- - contentUrl starts with /uploads/
+--   OR starts with http and ends with an image extension
+-- - contentLabel is non-empty
+-- - altText is currently empty
+UPDATE `History_Items`
+SET `altText` = `contentLabel`
+WHERE
+  (
+    `contentUrl` LIKE '/uploads/%'
+    OR (
+      LOWER(`contentUrl`) LIKE 'http%'
+      AND LOWER(`contentUrl`) REGEXP '\\.(png|jpe?g|gif|webp|bmp|svg|avif|tiff?|ico)$'
+    )
+  )
+  AND TRIM(COALESCE(`contentLabel`, '')) <> ''
+  AND TRIM(COALESCE(`altText`, '')) = '';
 
 COMMIT;

--- a/services/database/manual-migration-add-altText-to-items.sql
+++ b/services/database/manual-migration-add-altText-to-items.sql
@@ -1,0 +1,48 @@
+-- Manual migration: add altText columns to Items and History_Items if missing.
+-- Safe to run multiple times.
+--
+-- Usage examples:
+--   mysql -u <user> -p <database_name> < services/database/manual-migration-add-altText-to-items.sql
+--   docker compose exec db mysql -u root -p<password> <database_name> < /path/in/container/manual-migration-add-altText-to-items.sql
+
+START TRANSACTION;
+
+-- Add Items.altText only if it does not exist
+SET @items_alt_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'Items'
+    AND COLUMN_NAME = 'altText'
+);
+
+SET @sql_items := IF(
+  @items_alt_exists = 0,
+  'ALTER TABLE `Items` ADD COLUMN `altText` VARCHAR(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '''' AFTER `learnMoreUrl`;',
+  'SELECT ''Items.altText already exists - skipping'' AS message;'
+);
+
+PREPARE stmt_items FROM @sql_items;
+EXECUTE stmt_items;
+DEALLOCATE PREPARE stmt_items;
+
+-- Add History_Items.altText only if it does not exist
+SET @history_items_alt_exists := (
+  SELECT COUNT(*)
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND TABLE_NAME = 'History_Items'
+    AND COLUMN_NAME = 'altText'
+);
+
+SET @sql_history_items := IF(
+  @history_items_alt_exists = 0,
+  'ALTER TABLE `History_Items` ADD COLUMN `altText` VARCHAR(1000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '''' AFTER `contentLabel`;',
+  'SELECT ''History_Items.altText already exists - skipping'' AS message;'
+);
+
+PREPARE stmt_history_items FROM @sql_history_items;
+EXECUTE stmt_history_items;
+DEALLOCATE PREPARE stmt_history_items;
+
+COMMIT;


### PR DESCRIPTION
This PR fixes issue #95: how card graphics handle accessibility text and fixes an error while editing thumbnail galleries.
- Card image alt text now supports more edge cases, including thumbnail galleries.
- contentLabel and altText can now be different instead of being treated as the same field.
- If altText is empty but contentLabel is filled, the app now uses contentLabel as the fallback alt text.
- Fixed a crash: Cannot read properties of undefined (reading 'typeName') that occurred when all text items were deleted from a thumbnail gallery and the card was saved.
- Adds migration script `‎services/database/manual-migration-add-altText-to-items.sql‎` to add the altText columns to Items and History_Items (idempotently). See README/DOCKER.md for instructions on how to run this script.