### PR TITLE
fix: remove queries filling in altText with contentLabel

### DIFF
--- a/services/database/manual-migration-add-altText-to-items.sql
+++ b/services/database/manual-migration-add-altText-to-items.sql
@@ -26,24 +26,7 @@ PREPARE stmt_items FROM @sql_items;
 EXECUTE stmt_items;
 DEALLOCATE PREPARE stmt_items;
 
--- Backfill Items.altText from contentLabel for image URLs only.
--- Rules:
--- - contentUrl starts with /uploads/
---   OR starts with http and ends with an image extension
--- - contentLabel is non-empty
--- - altText is currently empty
-UPDATE `Items`
-SET `altText` = `contentLabel`
-WHERE
-  (
-    `contentUrl` LIKE '/uploads/%'
-    OR (
-      LOWER(`contentUrl`) LIKE 'http%'
-      AND LOWER(`contentUrl`) REGEXP '\\.(png|jpe?g|gif|webp|bmp|svg|avif|tiff?|ico)$'
-    )
-  )
-  AND TRIM(COALESCE(`contentLabel`, '')) <> ''
-  AND TRIM(COALESCE(`altText`, '')) = '';
+
 
 -- Add History_Items.altText only if it does not exist
 SET @history_items_alt_exists := (
@@ -64,23 +47,6 @@ PREPARE stmt_history_items FROM @sql_history_items;
 EXECUTE stmt_history_items;
 DEALLOCATE PREPARE stmt_history_items;
 
--- Backfill History_Items.altText from contentLabel for image URLs only.
--- Rules:
--- - contentUrl starts with /uploads/
---   OR starts with http and ends with an image extension
--- - contentLabel is non-empty
--- - altText is currently empty
-UPDATE `History_Items`
-SET `altText` = `contentLabel`
-WHERE
-  (
-    `contentUrl` LIKE '/uploads/%'
-    OR (
-      LOWER(`contentUrl`) LIKE 'http%'
-      AND LOWER(`contentUrl`) REGEXP '\\.(png|jpe?g|gif|webp|bmp|svg|avif|tiff?|ico)$'
-    )
-  )
-  AND TRIM(COALESCE(`contentLabel`, '')) <> ''
-  AND TRIM(COALESCE(`altText`, '')) = '';
+
 
 COMMIT;


### PR DESCRIPTION
Removed the copying of contentLabel into altText. 
This is redundant and not needed as screen readers will already see the label. A label complements an image while an alt text serves a different purpose of explaining what an image is. This is to be filled in manually as users make their content more accessible.