### PR TITLE
 Fix hidden graphic images caused by legacy empty rich-text labels

### DIFF
--- a/client/src/pages/ContentPage/Card/BulletPoint.css
+++ b/client/src/pages/ContentPage/Card/BulletPoint.css
@@ -97,6 +97,11 @@
 	align-items: flex-start;
 }
 
+.graphic-content {
+	flex: 0 1 auto;
+	min-width: 0;
+}
+
 .opportunity-desc-block {
 	margin-left: 0.3em;
 }

--- a/client/src/pages/ContentPage/Card/BulletPointGraphic.js
+++ b/client/src/pages/ContentPage/Card/BulletPointGraphic.js
@@ -50,7 +50,7 @@ function BulletPointGraphic(props) {
 
         {/* Container holding graphic image, text, and possibly a source */}
         <div
-          className={`${props.inline ? "inline-graphic mr-3" : "col"} ${
+          className={`${props.inline ? "inline-graphic mr-3" : "graphic-content col"} ${
             props.label.length ? "" : "indent-level-" + props.indentation
           } content-td pb-2`}
         >


### PR DESCRIPTION
## Problem
Some legacy graphic items have labels like `<p><br></p>` which are visually empty but still have a nonzero string length. That makes the graphic renderer choose the labeled layout path. In that layout, the image is inside a Bootstrap `.col`, and the responsive image scales to the column's computed width, which is 0 in this case with a visually empty label. 

The column collapses and results in the image being loaded in the DOM but rendered at 0px width, appearing as missing.

## Fix
Add a `graphic-content` class for non-inline graphics and override the Bootstrap `.col` flex behavior. This lets the graphic column shrink without collapsing to 0 around the visually empty label. 

Resolves #81 
Resolves #80 
