### PR TITLE
fix: explicitly set approved on insert into answers

### DIFF
--- a/models/quizzes.js
+++ b/models/quizzes.js
@@ -328,8 +328,8 @@ async function createQuiz(text, type, imageUrl, answers, pageId) {
       if (type !== 1 && type !== 4) {
         newCorrect = 1;
       }
-      const sql = "INSERT INTO Answers (questionId, text, correct, groupId) " +
-      "VALUES (?, ?, ?, ?);";
+      const sql = "INSERT INTO Answers (questionId, text, correct, groupId, approved) " +
+      "VALUES (?, ?, ?, ?, 0);";
       await pool.query(sql, [questionId, answers[i].text.trim().toLowerCase(), newCorrect, answers[i].groupId]);
     }
 
@@ -453,8 +453,8 @@ async function updateQuiz(text, type, imageUrl, answers, questionId) {
       if (type !== 1 && type !== 4) {
         newCorrect = 1;
       }
-      const sql = "INSERT INTO Answers (questionId, text, correct, groupId) " +
-      "VALUES (?, ?, ?, ?);";
+      const sql = "INSERT INTO Answers (questionId, text, correct, groupId, approved) " +
+      "VALUES (?, ?, ?, ?, 0);";
       await pool.query(sql, [questionId, answers[i].text.trim().toLowerCase(), newCorrect, answers[i].groupId]);
     }
 


### PR DESCRIPTION
Resolves #106

## Problem  

Quiz answers are pending by default, but the insert statements did not provide a value for the `approved` column. 
With the current stricter MariaDB schema, `Answers.approved` is `NOT NULL` and has no default, so those inserts failed.

## Fix

Explicitly insert with `approved = 0`