### PR TITLE
fix: repair dependabot config and clear two stuck advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
       - /
       - /client
     schedule:
-      interval: weekly    groups:
+      interval: weekly
+    groups:
       npm-dependencies:
         patterns:
           - "*"
@@ -17,14 +18,16 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly    groups:
+      interval: weekly
+    groups:
       github-actions:
         patterns:
           - "*"
   - package-ecosystem: docker
     directory: /docker/app
     schedule:
-      interval: weekly    groups:
+      interval: weekly
+    groups:
       docker:
         patterns:
           - "*"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9707,9 +9707,9 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-			"integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+			"integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/http-proxy": "^1.17.8",
@@ -25075,9 +25075,9 @@
 			}
 		},
 		"http-proxy-middleware": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-			"integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+			"integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
 			"requires": {
 				"@types/http-proxy": "^1.17.8",
 				"http-proxy": "^1.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3376,9 +3376,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
@@ -8720,9 +8720,9 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
 			"requires": {
 				"argparse": "^1.0.7",
 				"esprima": "^4.0.0"


### PR DESCRIPTION
## Summary

Two related fixes. The first is the important one.

### 1. The dependabot config on `dev` is invalid YAML and is being ignored entirely

Commit a534c1e collapsed `groups:` onto the `interval:` scalar in all three ecosystem blocks:

```yaml
      interval: weekly    groups:
```

which fails to parse:

```
(<unknown>): mapping values are not allowed in this context at line 9 column 33
```

Dependabot rejects an unparseable config from the default branch outright. **So since a534c1e, no grouped updates have run at all** — security updates kept firing individually and ungrouped, which is why single-package jobs like `npm_and_yarn in /client for http-proxy-middleware` are still appearing. The grouping this config was meant to introduce has never actually taken effect.

This restores the intended structure. Validated with a strict Draft7 check against SchemaStore's `dependabot-2.0.json`.

Note: `target-branch` is deliberately **omitted**, and this is load-bearing rather than merely redundant. `dev` is the default branch so PRs target it anyway — but groups do not apply to security updates *where `target-branch` is used*, keyed on the key being defined at all rather than its value. Defining it would silently disable the `npm-security` group.

### 2. Two advisories Dependabot structurally cannot fix

Dependabot resolves a package across the whole tree at once. With `react-scripts@5.0.1`'s frozen transitive pins, it reports `security_update_not_possible` — e.g. *"A patched version exists for http-proxy-middleware, but the available update path would downgrade react-scripts from 5.0.1 to 0.2.3"*. Bumping each package within its own declared range works fine, and is the same command dependabot-core itself shells out to (`npm update <pkg> --ignore-scripts --package-lock-only`).

| Package | Manifest | Change | Alert | Why it resolves |
|---|---|---|---|---|
| `js-yaml` | root | 3.14.2 → 3.15.0 | #107 | dependents `eslint` / `@eslint/eslintrc` require `^3.13.1` |
| `http-proxy-middleware` | client | 2.0.9 → 2.0.10 | #195 | sole dependent `webpack-dev-server` requires `^2.0.3` |

Alert #107 was originally going to be carried by Dependabot PR #118, but that PR was closed rather than merged, so the root fix never landed.

## Verification

- Committed config parses (Psych) with all three ecosystems and both groups intact
- No package resolution other than the two above changes in either lockfile
- `npm ci` clean in both root (535 pkgs) and client (1436 pkgs)
- Client production build passes using the Dockerfile's exact invocation (`DISABLE_ESLINT_PLUGIN=true npm run build`) — exit 0
- `npm audit` deltas: root 35 → 34, client 59 → 58; both targeted advisories confirmed cleared
- eslint and js-yaml load correctly in root

## Notes / follow-ups (not in this PR)

- The backlog is **130 open alerts** (84 client, 46 root). CRA is *not* the main driver — only 16 of 33 remaining client findings are react-scripts-blocked, and the 46 root alerts (multer, mysql2, jsonwebtoken, ajv) are unrelated to it. A Vite migration would address ~12% of alerts and none of the criticals.
- Once this merges, expect one grouped npm PR per week spanning both `/` and `/client`, plus a separate grouped security PR.
- Unrelated: `client/src/utilities/isExternalImageUrl.js` has pre-existing lint errors that only surface when the eslint plugin is enabled; CI does not see them because the Dockerfile disables it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)