### PR TITLE
fix: unblock the failing dependabot PRs (group majors out, pin cookie)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,18 @@ updates:
     schedule:
       interval: weekly
     groups:
+      # Majors are deliberately excluded: grouping them lumps every
+      # breaking change into one unreviewable PR. They still arrive,
+      # as individual PRs that can be reviewed and tested one at a time.
       npm-dependencies:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
         patterns:
           - "*"
+      # update-types is not supported for security-updates groups, so
+      # this group takes whatever version the advisory requires.
       npm-security:
         applies-to: security-updates
         patterns:

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,7 +12,7 @@
 				"@emotion/styled": "^11.3.0",
 				"@reduxjs/toolkit": "^2.9.0",
 				"bootstrap": "^5.3.8",
-				"cookie": "^0.4.1",
+				"cookie": "^0.7.2",
 				"diff-match-patch": "^1.0.5",
 				"dompurify": "^3.3.3",
 				"draft-js": "^0.11.7",
@@ -6280,9 +6280,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -8415,15 +8415,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/express/node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/express/node_modules/debug": {
@@ -22813,9 +22804,9 @@
 			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
 		},
 		"cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
 		},
 		"cookie-signature": {
 			"version": "1.0.7",
@@ -24230,11 +24221,6 @@
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
-				"cookie": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-					"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-				},
 				"debug": {
 					"version": "2.6.9",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
 		"@emotion/styled": "^11.3.0",
 		"@reduxjs/toolkit": "^2.9.0",
 		"bootstrap": "^5.3.8",
-		"cookie": "^0.4.1",
+		"cookie": "^0.7.2",
 		"diff-match-patch": "^1.0.5",
 		"dompurify": "^3.3.3",
 		"draft-js": "^0.11.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 				"assert": "^2.0.0",
 				"await-fs": "^1.0.0",
 				"concurrently": "^5.3.0",
-				"cookie": "^0.4.1",
+				"cookie": "^0.7.2",
 				"cookie-parser": "~1.4.4",
 				"cross-env": "^7.0.2",
 				"debug": "~2.6.9",
@@ -1049,9 +1049,9 @@
 			}
 		},
 		"node_modules/cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -1068,15 +1068,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/cookie-parser/node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/cookie-signature": {
@@ -2184,15 +2175,6 @@
 			},
 			"engines": {
 				"node": ">= 8.0.0"
-			}
-		},
-		"node_modules/express/node_modules/cookie": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/express/node_modules/http-errors": {
@@ -7195,9 +7177,9 @@
 			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
 		},
 		"cookie": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-			"integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
 		},
 		"cookie-parser": {
 			"version": "1.4.7",
@@ -7206,13 +7188,6 @@
 			"requires": {
 				"cookie": "0.7.2",
 				"cookie-signature": "1.0.6"
-			},
-			"dependencies": {
-				"cookie": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-					"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-				}
 			}
 		},
 		"cookie-signature": {
@@ -7971,11 +7946,6 @@
 				"vary": "~1.1.2"
 			},
 			"dependencies": {
-				"cookie": {
-					"version": "0.7.2",
-					"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-					"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="
-				},
 				"http-errors": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"assert": "^2.0.0",
 		"await-fs": "^1.0.0",
 		"concurrently": "^5.3.0",
-		"cookie": "^0.4.1",
+		"cookie": "^0.7.2",
 		"cookie-parser": "~1.4.4",
 		"cross-env": "^7.0.2",
 		"debug": "~2.6.9",


### PR DESCRIPTION
Fixes the two failing Dependabot PRs, #124 and #125. They fail for two different reasons and need two different fixes.

## 1. PR #124 — the group had no major-version filter

The `npm-dependencies` group used `patterns: "*"` with no `update-types`, so every available major landed in one PR:

- react 18 → 19, react-dom 18 → 19
- react-redux 8 → 9, react-icons 4 → 5
- express 4 → 5, gh-pages 2 → 6
- concurrently 5 → 10, cross-env 7 → 10
- @testing-library/react 14 → 16, cookie 0.4 → 2

That is not reviewable, and it broke the build. This restricts the group to `minor` and `patch`.

Majors still surface — but as **individual** PRs that can be reviewed and tested one at a time, rather than lumped together. If that turns out to be too noisy, the next step would be an `ignore` rule for `version-update:semver-major`, at the cost of losing visibility into what majors are available.

`update-types` is deliberately **not** set on `npm-security`. Per the docs it *"only affects version updates, not security updates"*, so the security group takes whatever the advisory requires regardless — which is why #125 needs a separate fix.

## 2. PR #125 — cookie 2.x removes the API both codebases use

Alerts #117 (client) and #61 (root) require `cookie >= 0.7.0`. The security group proposed `^2.0.1`, which broke the build:

```
Attempted import error: 'cookie' does not contain a default export (imported as 'cookie').
```

Both codebases consume `cookie` via its default/CJS export:

| File | Usage |
|---|---|
| `client/src/utilities/cookieAuth.js` | `import cookie from "cookie"` → `cookie.parse` |
| `services/authentication/cookieAuth.js` | `require("cookie")` → `cookie.parse`, `cookie.serialize` ×4 |

The break happens earlier than the major bump suggests:

| Version | `__esModule` marker | API | Default import |
|---|---|---|---|
| 0.4.2, **0.7.2** | no | `parse` / `serialize` | ✅ works |
| 1.0.0 – 1.1.1 | **yes** | `parse` / `serialize` | ❌ resolves to `exports.default` (undefined) |
| 2.x | ESM-only `exports` | **renamed** → `parseCookie` / `stringifyCookie` | ❌ |

cookie 1.0.0 added `Object.defineProperty(exports, "__esModule", { value: true })` to its CJS bundle, which makes webpack resolve a default import to a non-existent `exports.default`. 2.0.0 then renamed the API outright.

**`^0.7.2` satisfies the advisory, predates the `__esModule` marker, and keeps `parse`/`serialize` — so it clears both alerts with zero code changes.**

Adopting 2.x is a genuine migration touching auth middleware (JWT cookie parsing and `Set-Cookie` serialization). That deserves its own PR and its own testing, not a ride-along in a dependency bump.

## Verification

- `parse`/`serialize` exercised against the real call patterns, including `sameSite: true` → `SameSite=Strict`, `maxAge`, and `expires`
- Full resolution-map diff of both lockfiles: **no** package other than `cookie` changes
- `npm ci` clean in both root (533 pkgs) and client (1435 pkgs)
- Client production build passes with the Dockerfile's exact invocation (`DISABLE_ESLINT_PLUGIN=true npm run build`) — `Compiled successfully`
- `npm audit`: root 34 → 33, client 58 → 57; cookie confirmed cleared in both
- Config validated with a YAML parse; `npm-dependencies` = `version-updates` + `[minor, patch]`, `npm-security` unrestricted

## After merging

1. **Close #124 and #125** — both are built on the pre-fix `dev` and will not recover on their own. Dependabot regenerates them on its next run.
2. The regenerated npm-dependencies PR should be minor/patch only.
3. The regenerated npm-security PR will drop `cookie` (alerts #117/#61 close on merge).

⚠️ **The regenerated #125 will still carry `multer 1.4.4 → 2.2.0` and `ws 3.3.2 → 5.2.5`** — security-driven majors that `update-types` cannot filter. They compile fine, so **CI will go green**, but nothing here tests the root server: `routes/files.js` uses `multer.diskStorage` for uploads, and multer 2.x changed its API. Worth exercising file upload manually before merging that one — a green check on a security-group PR is not sufficient evidence here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)