### PR TITLE
chore(deps): updates node docker image to latest lts alias of 24

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,5 +1,5 @@
 # Use Node.js 24 on Alpine
-FROM node:24-alpine3.21
+FROM node:24-alpine
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
Modifes the node docker image to use the LTS alias for alpine v24 of node.