### PR TITLE
chore(deps): update root node dependencies

### DIFF
--- a/client/src/components/General/RichTextEditor.css
+++ b/client/src/components/General/RichTextEditor.css
@@ -10,3 +10,11 @@
 .ql-editor {
   white-space: break-spaces;
 }
+
+.text-editor.hide-toolbar .ql-toolbar.ql-snow {
+  display: none;
+}
+
+.text-editor.hide-toolbar .ql-container.ql-snow {
+  border: none;
+}

--- a/client/src/components/General/RichTextEditor.js
+++ b/client/src/components/General/RichTextEditor.js
@@ -35,19 +35,12 @@ function RichTextEditor(props) {
   Size.whitelist = ["small", "medium", "large", "huge"];
   Quill.register(Size, true);
 
-  const theme = props.showToolbar() ? "snow" : "bubble";
+  // Keep the theme stable to avoid rebuilding Quill when toolbar visibility changes.
+  const toolbarVisible = props.showToolbar();
 
   return (
-    <div className={`text-editor ${props.showToolbar() ? "" : "simple-text-border"}`}>
+    <div className={`text-editor ${toolbarVisible ? "" : "simple-text-border hide-toolbar"}`}>
       <ReactQuill
-        // Keying on theme forces React to unmount + remount ReactQuill when the
-        // theme changes, instead of letting react-quill regenerate the editor
-        // in place. react-quill 2.0.0's in-place regeneration relies on
-        // findDOMNode and restores the prior selection during the rebuild; under
-        // React 18 that races the DOM update and throws "addRange(): The given
-        // range isn't in document", leaving the editor blank. A clean remount
-        // rebuilds from `value` with no stale selection to restore.
-        key={theme}
         preserveWhitespace={true}
         value={props.value}
         onChange={(text) => props.onChange(text)}
@@ -55,7 +48,7 @@ function RichTextEditor(props) {
         modules={modules}
         formats={formats}
         placeholder={props.placeHolder}
-        theme={theme}
+        theme="snow"
       />
     </div>
   );

--- a/client/src/components/General/RichTextEditor.js
+++ b/client/src/components/General/RichTextEditor.js
@@ -35,9 +35,19 @@ function RichTextEditor(props) {
   Size.whitelist = ["small", "medium", "large", "huge"];
   Quill.register(Size, true);
 
+  const theme = props.showToolbar() ? "snow" : "bubble";
+
   return (
     <div className={`text-editor ${props.showToolbar() ? "" : "simple-text-border"}`}>
       <ReactQuill
+        // Keying on theme forces React to unmount + remount ReactQuill when the
+        // theme changes, instead of letting react-quill regenerate the editor
+        // in place. react-quill 2.0.0's in-place regeneration relies on
+        // findDOMNode and restores the prior selection during the rebuild; under
+        // React 18 that races the DOM update and throws "addRange(): The given
+        // range isn't in document", leaving the editor blank. A clean remount
+        // rebuilds from `value` with no stale selection to restore.
+        key={theme}
         preserveWhitespace={true}
         value={props.value}
         onChange={(text) => props.onChange(text)}
@@ -45,7 +55,7 @@ function RichTextEditor(props) {
         modules={modules}
         formats={formats}
         placeholder={props.placeHolder}
-        theme={props.showToolbar() ? "snow" : "bubble"}
+        theme={theme}
       />
     </div>
   );

--- a/client/src/pages/ContentPage/Card/ConstructCardModal.js
+++ b/client/src/pages/ContentPage/Card/ConstructCardModal.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useState, useCallback, Fragment} from "react";
+import React, {useEffect, useState, Fragment} from "react";
 import {Modal, Button, Row, Col, Form} from "react-bootstrap";
 import {logout} from "../../../utilities/cookieAuth";
 import {getAgreement} from "../../../utilities/agreementMode";
@@ -32,7 +32,6 @@ function ConstructCardModal(props) {
   const [selectedItems, setSelectedItems] = useState(0);
   const [imageAgreement, setImageAgreement] = useState(getAgreement("image"));
   const [showAgreement, setShowAgreement] = useState(false);
-  const [controlHeld, setControlHeld] = useState(false);
   const [imageTerms] = useState(UPLOAD_TERMS);
 
   // Problem: If user submits a blank graphic label, it would save as "<p><br></p>" instead of an empty string
@@ -148,40 +147,10 @@ function ConstructCardModal(props) {
     setPureCounter(pure + 1);
   }, [items, items.length, counter]);
 
-  // add CTRL key down listener
-  useEffect(() => {
-    document.addEventListener("keydown", ctrlDown, false);
-    return () => {
-      document.removeEventListener("keydown", ctrlDown, false);
-    };
-  }, []);
-
-  // add CTRL key up listener
-  useEffect(() => {
-    document.addEventListener("keyup", ctrlUp, false);
-    return () => {
-      document.removeEventListener("keyup", ctrlUp, false);
-    };
-  }, []);
-
   // Clear error messages whenever the modal is opened or closed
   useEffect(() => {
     setErrorMessage("");
   }, [props.show]);
-
-  // Set the CTRL key held state to false
-  const ctrlUp = useCallback((event) => {
-    if (event.keyCode === 17) {
-      setControlHeld(false);
-    }
-  }, []);
-
-  // Set the CTRL key held state to true
-  const ctrlDown = useCallback((event) => {
-    if (event.keyCode === 17) {
-      setControlHeld(true);
-    }
-  }, []);
 
   // Makes a copy of the items in the props
   function generateItems(itemList) {
@@ -1294,9 +1263,10 @@ function ConstructCardModal(props) {
     setImageAgreement(true);
   }
 
-  // handle selecting one or more items
-  function itemSelection(targetItem) {
-    if (controlHeld && selectedItems.length) {
+  // Read the modifier from the click to avoid stale multi-select state.
+  function itemSelection(targetItem, event) {
+    const multiSelect = !!(event && (event.ctrlKey || event.metaKey));
+    if (multiSelect && selectedItems.length) {
 
       // don't allow selecting the same item more than once
       for (let i = 0; i < selectedItems.length; i++) {
@@ -1470,7 +1440,7 @@ function ConstructCardModal(props) {
               className={`mb-2 mx-2 ${isSelected(item) ? "modal-selected-item" : ""}
                 ${item.internal ? "internal-modal-item" : ""} ${item.inline ? "inline-modal-item" : ""}`}
               key={item.counterId}
-              onClick={() => itemSelection(item.counterId)}
+              onClick={(e) => itemSelection(item.counterId, e)}
             >
               <div className="input-group">
                 <Indent indentLevel={item.indentation} />

--- a/models/headers.js
+++ b/models/headers.js
@@ -325,8 +325,8 @@ async function publishHeader(headerId) {
     }
 
     // save the published data to history
-    sql = "INSERT INTO History_Headers (pageId, headerId, title, internal) " +
-    "SELECT pageId, headerId, title, internal FROM Headers " +
+    sql = "INSERT INTO History_Headers (pageId, headerId, title, internal, removed) " +
+    "SELECT pageId, headerId, title, internal, 0 AS removed FROM Headers " +
     "WHERE Headers.approved = 1 AND Headers.headerId = ?;";
     await pool.query(sql, [headerId]);
 

--- a/models/pages.js
+++ b/models/pages.js
@@ -716,8 +716,8 @@ async function publishPage(pageId) {
     }
 
     // save the published data to history
-    sql = "INSERT INTO History_Pages (pageId, pageType, name, title, description, imageUrl, internal) " +
-    "SELECT pageId, pageType, name, title, description, imageUrl, internal FROM Pages " +
+    sql = "INSERT INTO History_Pages (pageId, pageType, name, title, description, imageUrl, internal, removed) " +
+    "SELECT pageId, pageType, name, title, description, imageUrl, internal, 0 AS removed FROM Pages " +
     "WHERE Pages.approved = 1 AND Pages.pageId = ?;";
     await pool.query(sql, [pageId]);
 

--- a/models/quizzes.js
+++ b/models/quizzes.js
@@ -531,8 +531,8 @@ async function submitObservations(userId, pageId, observations) {
 
     // create the new observations
     for (let i = 0; i < observations.length; i++) {
-      sql = "INSERT INTO Observations (pageId, userId, type, text) " +
-      "VALUES (?, ?, ?, ?);";
+      sql = "INSERT INTO Observations (pageId, userId, type, text, hidden) " +
+      "VALUES (?, ?, ?, ?, 0);";
       await pool.query(sql, [pageId, userId, observations[i].type, observations[i].text.trim()]);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,14 @@
 				"express": "^5.2.1",
 				"express-validator": "^6.5.0",
 				"http-errors": "~1.6.3",
-				"jsonwebtoken": "^8.5.1",
+				"jsonwebtoken": "^9.0.3",
 				"moment": "^2.27.0",
 				"morgan": "~1.11.0",
 				"multer": "^2.2.0",
-				"mysql2": "^2.1.0",
+				"mysql2": "^3.23.1",
 				"react-quill": "^1.3.5",
 				"sanitize-html": "^2.17.6",
-				"serve": "^11.3.2",
+				"serve": "^14.2.6",
 				"validator": "^13.15.35"
 			},
 			"devDependencies": {
@@ -167,6 +167,16 @@
 			"deprecated": "Use @eslint/object-schema instead",
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/@types/node": {
+			"version": "26.1.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+			"integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~8.3.0"
+			}
+		},
 		"node_modules/@types/quill": {
 			"version": "1.3.10",
 			"resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
@@ -177,23 +187,10 @@
 			}
 		},
 		"node_modules/@zeit/schemas": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.6.0.tgz",
-			"integrity": "sha512-uUrgZ8AxS+Lio0fZKAipJjAh415JyrOZowliZAzmnJSsf7piVL5w+G0+gFJ0KSu3QRhvui/7zuvpLz03YjXAhg==",
+			"version": "2.36.0",
+			"resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+			"integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
 			"license": "MIT"
-		},
-		"node_modules/accepts": {
-			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-types": "~2.1.34",
-				"negotiator": "0.6.3"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
 		},
 		"node_modules/acorn": {
 			"version": "7.4.1",
@@ -233,12 +230,41 @@
 			}
 		},
 		"node_modules/ansi-align": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-			"integrity": "sha512-TdlOggdA/zURfMYa7ABC66j+oqfMew58KpJMbUlH3bcZP1b+cBHIHDDn5uH9INsxrHBPjsqM0tDB4jPTF/vgJA==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+			"integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
 			"license": "ISC",
 			"dependencies": {
-				"string-width": "^2.0.0"
+				"string-width": "^4.1.0"
+			}
+		},
+		"node_modules/ansi-align/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/ansi-align/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-align/node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/ansi-colors": {
@@ -312,9 +338,9 @@
 			"license": "MIT"
 		},
 		"node_modules/arg": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-2.0.0.tgz",
-			"integrity": "sha512-XxNTUzKnz1ctK3ZIcI2XUPlD96wbHP2nGqkPKpvk/HNRlPveYrXIVSTk9m3LcqOgDPg3B1nMvdV/K8wZd7PG4w==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+			"integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
 			"license": "MIT"
 		},
 		"node_modules/argparse": {
@@ -527,6 +553,15 @@
 				"node": ">=7.10.0"
 			}
 		},
+		"node_modules/aws-ssl-profiles": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+			"integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -703,21 +738,105 @@
 			}
 		},
 		"node_modules/boxen": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-			"integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
+			"integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-align": "^2.0.0",
-				"camelcase": "^4.0.0",
-				"chalk": "^2.0.1",
-				"cli-boxes": "^1.0.0",
-				"string-width": "^2.0.0",
-				"term-size": "^1.2.0",
-				"widest-line": "^2.0.0"
+				"ansi-align": "^3.0.1",
+				"camelcase": "^7.0.0",
+				"chalk": "^5.0.1",
+				"cli-boxes": "^3.0.0",
+				"string-width": "^5.1.2",
+				"type-fest": "^2.13.0",
+				"widest-line": "^4.0.1",
+				"wrap-ansi": "^8.0.1"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/boxen/node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/boxen/node_modules/ansi-styles": {
+			"version": "6.2.3",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/boxen/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/boxen/node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/boxen/node_modules/type-fest": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/boxen/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -831,12 +950,15 @@
 			}
 		},
 		"node_modules/camelcase": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-			"integrity": "sha512-FxAv7HpHrXbh3aPo4o2qxHay2lkLY3x5Mw3KeE4KQE8ysVfziWeRZDwcjauvwBSGEC/nXUPzZy8zeh4HokqOnw==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+			"integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=4"
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/chalk": {
@@ -851,6 +973,91 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/chalk-template": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+			"integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk-template?sponsor=1"
+			}
+		},
+		"node_modules/chalk-template/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/chalk-template/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chalk-template/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/chalk-template/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
+		},
+		"node_modules/chalk-template/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/chalk-template/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/chalk/node_modules/supports-color": {
@@ -891,25 +1098,32 @@
 			}
 		},
 		"node_modules/cli-boxes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-			"integrity": "sha512-3Fo5wu8Ytle8q9iCzS4D2MWVL2X7JVWRiS1BnXbTFDhS9c/REkM9vd1AmabsoZoY5/dGi5TT9iKL8Kb6DeBRQg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+			"integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/clipboardy": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-			"integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+			"integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
 			"license": "MIT",
 			"dependencies": {
-				"arch": "^2.1.0",
-				"execa": "^0.8.0"
+				"arch": "^2.2.0",
+				"execa": "^5.1.1",
+				"is-wsl": "^2.2.0"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cliui": {
@@ -995,37 +1209,22 @@
 			}
 		},
 		"node_modules/compression": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
-			"integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+			"integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
 			"license": "MIT",
 			"dependencies": {
-				"accepts": "~1.3.5",
-				"bytes": "3.0.0",
-				"compressible": "~2.0.14",
+				"bytes": "3.1.2",
+				"compressible": "~2.0.18",
 				"debug": "2.6.9",
-				"on-headers": "~1.0.1",
-				"safe-buffer": "5.1.2",
+				"negotiator": "~0.6.4",
+				"on-headers": "~1.1.0",
+				"safe-buffer": "5.2.1",
 				"vary": "~1.1.2"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
 			}
-		},
-		"node_modules/compression/node_modules/bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/compression/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"license": "MIT"
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -1448,6 +1647,12 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+			"license": "MIT"
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
@@ -2069,82 +2274,27 @@
 			"license": "MIT"
 		},
 		"node_modules/execa": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-			"integrity": "sha512-zDWS+Rb1E8BlqqhALSt9kUhss8Qq4nN3iof3gsOdyINksElaPyNBtKUMTR62qhvgVWR0CqCX7sdnKe4MnUbFEA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
 			"license": "MIT",
 			"dependencies": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/execa/node_modules/cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-			"license": "MIT",
-			"dependencies": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			}
-		},
-		"node_modules/execa/node_modules/lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"license": "ISC",
-			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
-			}
-		},
-		"node_modules/execa/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
+				"node": ">=10"
 			},
-			"engines": {
-				"node": ">=0.10.0"
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
-		},
-		"node_modules/execa/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/execa/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
-			}
-		},
-		"node_modules/execa/node_modules/yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-			"license": "ISC"
 		},
 		"node_modules/express": {
 			"version": "5.2.1",
@@ -2392,15 +2542,6 @@
 				}
 			],
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/fast-url-parser": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
-			"integrity": "sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==",
-			"license": "MIT",
-			"dependencies": {
-				"punycode": "^1.3.2"
-			}
 		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
@@ -2666,12 +2807,15 @@
 			}
 		},
 		"node_modules/get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=4"
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-symbol-description": {
@@ -2922,6 +3066,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=10.17.0"
 			}
 		},
 		"node_modules/iconv-lite": {
@@ -3195,6 +3348,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3338,6 +3506,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-port-reachable": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
+			"integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-promise": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -3398,12 +3578,15 @@
 			}
 		},
 		"node_modules/is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-string": {
@@ -3502,6 +3685,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3570,12 +3765,12 @@
 			"license": "MIT"
 		},
 		"node_modules/jsonwebtoken": {
-			"version": "8.5.1",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-			"integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
 			"license": "MIT",
 			"dependencies": {
-				"jws": "^3.2.2",
+				"jws": "^4.0.1",
 				"lodash.includes": "^4.3.0",
 				"lodash.isboolean": "^3.0.3",
 				"lodash.isinteger": "^4.0.4",
@@ -3584,11 +3779,11 @@
 				"lodash.isstring": "^4.0.1",
 				"lodash.once": "^4.0.0",
 				"ms": "^2.1.1",
-				"semver": "^5.6.0"
+				"semver": "^7.5.4"
 			},
 			"engines": {
-				"node": ">=4",
-				"npm": ">=1.4.28"
+				"node": ">=12",
+				"npm": ">=6"
 			}
 		},
 		"node_modules/jsonwebtoken/node_modules/ms": {
@@ -3596,15 +3791,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
-		},
-		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"license": "ISC",
-			"bin": {
-				"semver": "bin/semver"
-			}
 		},
 		"node_modules/jsx-ast-utils": {
 			"version": "3.3.5",
@@ -3623,9 +3809,9 @@
 			}
 		},
 		"node_modules/jwa": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
-			"integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
 			"license": "MIT",
 			"dependencies": {
 				"buffer-equal-constant-time": "^1.0.1",
@@ -3634,12 +3820,12 @@
 			}
 		},
 		"node_modules/jws": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
-			"integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
 			"license": "MIT",
 			"dependencies": {
-				"jwa": "^1.4.2",
+				"jwa": "^2.0.1",
 				"safe-buffer": "^5.0.1"
 			}
 		},
@@ -3746,9 +3932,9 @@
 			"license": "MIT"
 		},
 		"node_modules/long": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/loose-envify": {
@@ -3763,22 +3949,10 @@
 				"loose-envify": "cli.js"
 			}
 		},
-		"node_modules/lru-cache": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/lru.min": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.3.tgz",
-			"integrity": "sha512-Lkk/vx6ak3rYkRR0Nhu4lFUT2VDnQSxBe8Hbl7f36358p6ow8Bnvr8lrLt98H8J1aGxfhbX4Fs5tYg2+FTwr5Q==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+			"integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
 			"license": "MIT",
 			"engines": {
 				"bun": ">=1.0.0",
@@ -3820,6 +3994,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"license": "MIT"
+		},
 		"node_modules/mime-db": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3839,6 +4019,15 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/minimatch": {
@@ -3890,14 +4079,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"node_modules/morgan/node_modules/on-headers": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
-			"integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3923,34 +4104,25 @@
 			}
 		},
 		"node_modules/mysql2": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
-			"integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
+			"version": "3.23.1",
+			"resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.1.tgz",
+			"integrity": "sha512-tTuRnC7qCet2IOfSNMYZ5SwXuBnfvBPAcIA28P0gtruXyZlU1LMxA6uha32kYypoFgyYklMqhLWwt4laYwXR/Q==",
 			"license": "MIT",
 			"dependencies": {
-				"denque": "^2.0.1",
+				"aws-ssl-profiles": "^1.1.2",
+				"denque": "^2.1.0",
 				"generate-function": "^2.3.1",
-				"iconv-lite": "^0.6.3",
-				"long": "^4.0.0",
-				"lru-cache": "^6.0.0",
-				"named-placeholders": "^1.1.2",
-				"seq-queue": "^0.0.5",
-				"sqlstring": "^2.3.2"
+				"iconv-lite": "^0.7.2",
+				"long": "^5.3.2",
+				"lru.min": "^1.1.4",
+				"named-placeholders": "^1.1.6",
+				"sql-escaper": "^1.5.1"
 			},
 			"engines": {
 				"node": ">= 8.0"
-			}
-		},
-		"node_modules/mysql2/node_modules/iconv-lite": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
-			"engines": {
-				"node": ">=0.10.0"
+			"peerDependencies": {
+				"@types/node": ">= 8"
 			}
 		},
 		"node_modules/named-placeholders": {
@@ -3989,9 +4161,9 @@
 			"license": "MIT"
 		},
 		"node_modules/negotiator": {
-			"version": "0.6.3",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+			"integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -4118,24 +4290,15 @@
 			}
 		},
 		"node_modules/npm-run-path": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-			"integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+			"integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
 			"license": "MIT",
 			"dependencies": {
-				"path-key": "^2.0.0"
+				"path-key": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/npm-run-path/node_modules/path-key": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-			"integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/object-assign": {
@@ -4271,9 +4434,9 @@
 			}
 		},
 		"node_modules/on-headers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-			"integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+			"integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -4286,6 +4449,21 @@
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+			"integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/optionator": {
@@ -4321,15 +4499,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/p-limit": {
@@ -4569,23 +4738,11 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
-			"license": "ISC"
-		},
 		"node_modules/pstree.remy": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
 			"integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
 			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
 			"license": "MIT"
 		},
 		"node_modules/qs": {
@@ -5227,44 +5384,43 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
-		"node_modules/seq-queue": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
-			"integrity": "sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q=="
-		},
 		"node_modules/serve": {
-			"version": "11.3.2",
-			"resolved": "https://registry.npmjs.org/serve/-/serve-11.3.2.tgz",
-			"integrity": "sha512-yKWQfI3xbj/f7X1lTBg91fXBP0FqjJ4TEi+ilES5yzH0iKJpN5LjNb1YzIfQg9Rqn4ECUS2SOf2+Kmepogoa5w==",
+			"version": "14.2.6",
+			"resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+			"integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@zeit/schemas": "2.6.0",
-				"ajv": "6.5.3",
-				"arg": "2.0.0",
-				"boxen": "1.3.0",
-				"chalk": "2.4.1",
-				"clipboardy": "1.2.3",
-				"compression": "1.7.3",
-				"serve-handler": "6.1.3",
-				"update-check": "1.5.2"
+				"@zeit/schemas": "2.36.0",
+				"ajv": "8.18.0",
+				"arg": "5.0.2",
+				"boxen": "7.0.0",
+				"chalk": "5.0.1",
+				"chalk-template": "0.4.0",
+				"clipboardy": "3.0.0",
+				"compression": "1.8.1",
+				"is-port-reachable": "4.0.0",
+				"serve-handler": "6.1.7",
+				"update-check": "1.5.4"
 			},
 			"bin": {
-				"serve": "bin/serve.js"
+				"serve": "build/main.js"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/serve-handler": {
-			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
-			"integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+			"version": "6.1.7",
+			"resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+			"integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "3.0.0",
 				"content-disposition": "0.5.2",
-				"fast-url-parser": "1.1.3",
 				"mime-types": "2.1.18",
-				"minimatch": "3.0.4",
+				"minimatch": "3.1.5",
 				"path-is-inside": "1.0.2",
-				"path-to-regexp": "2.2.1",
+				"path-to-regexp": "3.3.0",
 				"range-parser": "1.2.0"
 			}
 		},
@@ -5307,22 +5463,10 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/serve-handler/node_modules/minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/serve-handler/node_modules/path-to-regexp": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
-			"integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+			"integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
 			"license": "MIT"
 		},
 		"node_modules/serve-handler/node_modules/range-parser": {
@@ -5354,48 +5498,38 @@
 			}
 		},
 		"node_modules/serve/node_modules/ajv": {
-			"version": "6.5.3",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-			"integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^2.0.1",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.4.1",
-				"uri-js": "^4.2.2"
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/serve/node_modules/chalk": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+			"integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
 			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
 			"engines": {
-				"node": ">=4"
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/serve/node_modules/fast-deep-equal": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-			"integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
+		"node_modules/serve/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
 			"license": "MIT"
-		},
-		"node_modules/serve/node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/set-blocking": {
 			"version": "2.0.0",
@@ -5687,13 +5821,19 @@
 			"integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/sqlstring": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
-			"integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+		"node_modules/sql-escaper": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.5.1.tgz",
+			"integrity": "sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
+				"bun": ">=1.0.0",
+				"deno": ">=2.0.0",
+				"node": ">=12.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
 			}
 		},
 		"node_modules/statuses": {
@@ -5736,37 +5876,53 @@
 			}
 		},
 		"node_modules/string-width": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
 			"license": "MIT",
 			"dependencies": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/string-width/node_modules/ansi-regex": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
-			"integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=4"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
+		"node_modules/string-width/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"license": "MIT"
+		},
 		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-			"integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
 			"license": "MIT",
 			"dependencies": {
-				"ansi-regex": "^3.0.0"
+				"ansi-regex": "^6.2.2"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/string.prototype.matchall": {
@@ -5879,13 +6035,13 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/strip-eof": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-			"integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+		"node_modules/strip-final-newline": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=6"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -5990,96 +6146,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/term-size": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-			"integrity": "sha512-7dPUZQGy/+m3/wjVz3ZW5dobSoD/02NxJpoXUX0WIyjfVS3l0c+b/+9phIDFA7FHzkYtwtMFgeGZ/Y8jVTeqQQ==",
-			"license": "MIT",
-			"dependencies": {
-				"execa": "^0.7.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/term-size/node_modules/cross-spawn": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-			"integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
-			"license": "MIT",
-			"dependencies": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
-			}
-		},
-		"node_modules/term-size/node_modules/execa": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-			"integrity": "sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==",
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/term-size/node_modules/lru-cache": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-			"license": "ISC",
-			"dependencies": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
-			}
-		},
-		"node_modules/term-size/node_modules/shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/term-size/node_modules/shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/term-size/node_modules/which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"which": "bin/which"
-			}
-		},
-		"node_modules/term-size/node_modules/yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
-			"license": "ISC"
 		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
@@ -6280,6 +6346,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/undici-types": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -6290,9 +6363,9 @@
 			}
 		},
 		"node_modules/update-check": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.2.tgz",
-			"integrity": "sha512-1TrmYLuLj/5ZovwUS7fFd1jMH3NnFDN1y1A8dboedIDt7zs/zJMo6TwwlhYKkSeEwzleeiSBV5/3c9ufAQWDaQ==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+			"integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
 			"license": "MIT",
 			"dependencies": {
 				"registry-auth-token": "3.3.2",
@@ -6493,15 +6566,18 @@
 			}
 		},
 		"node_modules/widest-line": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-			"integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+			"integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
 			"license": "MIT",
 			"dependencies": {
-				"string-width": "^2.1.1"
+				"string-width": "^5.0.1"
 			},
 			"engines": {
-				"node": ">=4"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/word-wrap": {
@@ -6581,12 +6657,6 @@
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
 			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-			"license": "ISC"
-		},
-		"node_modules/yallist": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"license": "ISC"
 		},
 		"node_modules/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -217,9 +217,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -721,9 +721,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -2378,9 +2378,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-			"integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"funding": [
 				{
 					"type": "github",
@@ -2390,7 +2390,8 @@
 					"type": "opencollective",
 					"url": "https://opencollective.com/fastify"
 				}
-			]
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-url-parser": {
 			"version": "1.1.3",
@@ -3841,9 +3842,9 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -4469,9 +4470,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5940,9 +5941,9 @@
 			}
 		},
 		"node_modules/table/node_modules/ajv": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"morgan": "~1.11.0",
 				"multer": "^2.2.0",
 				"mysql2": "^3.23.1",
-				"react-quill": "^1.3.5",
+				"react-quill": "^2.0.0",
 				"sanitize-html": "^2.17.6",
 				"serve": "^14.2.6",
 				"validator": "^13.15.35"
@@ -1318,16 +1318,6 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
 			"integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
 			"license": "MIT"
-		},
-		"node_modules/create-react-class": {
-			"version": "15.7.0",
-			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
-			"integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.3.1",
-				"object-assign": "^4.1.1"
-			}
 		},
 		"node_modules/cross-env": {
 			"version": "7.0.3",
@@ -4305,6 +4295,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4718,6 +4709,7 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"loose-envify": "^1.4.0",
@@ -4868,50 +4860,52 @@
 			}
 		},
 		"node_modules/react": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2"
+				"loose-envify": "^1.1.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/react-dom-factories": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/react-dom-factories/-/react-dom-factories-1.0.2.tgz",
-			"integrity": "sha512-Bmic2N3oKji7vw9qjDr2dmwHvOATbFSnKy7EH0uT/qjvzIUsiXp6Yquk72LJ3WfMtRnq3ujXMMo7GsJeLPfFWw==",
-			"license": "MIT"
+		"node_modules/react-dom": {
+			"version": "18.3.1",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0",
+				"scheduler": "^0.23.2"
+			},
+			"peerDependencies": {
+				"react": "^18.3.1"
+			}
 		},
 		"node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/react-quill": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/react-quill/-/react-quill-1.3.5.tgz",
-			"integrity": "sha512-/W/rNCW+6QpGz8yQ9tFK5Ka/h/No1RqrcOOvCIOR092OiKzRFlU2xbPEwiP3Wgy/Dx13pi1YhjReDMX/5uotJg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+			"integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/quill": "1.3.10",
-				"create-react-class": "^15.6.0",
+				"@types/quill": "^1.3.10",
 				"lodash": "^4.17.4",
-				"prop-types": "^15.5.10",
-				"quill": "^1.3.7",
-				"react-dom-factories": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8.x"
+				"quill": "^1.3.7"
 			},
 			"peerDependencies": {
-				"react": "^0.14.9 || ^15.3.0 || ^16.0.0"
+				"react": "^16 || ^17 || ^18",
+				"react-dom": "^16 || ^17 || ^18"
 			}
 		},
 		"node_modules/read-pkg": {
@@ -5270,6 +5264,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/scheduler": {
+			"version": "0.23.2",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"loose-envify": "^1.1.0"
 			}
 		},
 		"node_modules/semver": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"morgan": "~1.11.0",
 		"multer": "^2.2.0",
 		"mysql2": "^3.23.1",
-		"react-quill": "^1.3.5",
+		"react-quill": "^2.0.0",
 		"sanitize-html": "^2.17.6",
 		"serve": "^14.2.6",
 		"validator": "^13.15.35"

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
 		"express": "^5.2.1",
 		"express-validator": "^6.5.0",
 		"http-errors": "~1.6.3",
-		"jsonwebtoken": "^8.5.1",
+		"jsonwebtoken": "^9.0.3",
 		"moment": "^2.27.0",
 		"morgan": "~1.11.0",
 		"multer": "^2.2.0",
-		"mysql2": "^2.1.0",
+		"mysql2": "^3.23.1",
 		"react-quill": "^1.3.5",
 		"sanitize-html": "^2.17.6",
-		"serve": "^11.3.2",
+		"serve": "^14.2.6",
 		"validator": "^13.15.35"
 	},
 	"devDependencies": {


### PR DESCRIPTION
 - Ran `npm audit fix --force` for the root dependencies.
  - Updated `react-quill` to 2.0.0. This exposed an issue where switching between the `snow` and `bubble` themes rebuilt the editor whenever card-item selection changed.
  - Updated the card editor to use a stable `snow` theme and hide the toolbar with CSS when necessary to maintain identical behavior while avoiding switching theme.
  - Refactored Ctrl/Cmd multi-select handling to read modifier keys directly from click events, preventing selection from becoming stuck. Selection got stuck with the editor theme fix, and this method is much cleaner too.
  - Fixed existing inserts that omitted required non-null values:
    - Set `removed` to `0` when creating page and header history records.
    - Set `hidden` to `0` when creating observations.