### PR TITLE
fix: secure training page mutations

### DIFF
--- a/client/src/pages/ContentPage/Page/LoadTrainingPages.js
+++ b/client/src/pages/ContentPage/Page/LoadTrainingPages.js
@@ -18,7 +18,9 @@ function LoadTrainingPages({role, mode}) {
     let result;
     try {
       result = await (
-        await fetch(`${API_URL}/training/source-page/${pageId}`)
+        await fetch(`${API_URL}/training/source-page/${pageId}`, {
+          credentials: "include"
+        })
       ).json();
       setTrainingPages(result);
     } catch (err) {

--- a/client/src/pages/ContentPage/Various/TrainingViewNameInput.js
+++ b/client/src/pages/ContentPage/Various/TrainingViewNameInput.js
@@ -8,7 +8,7 @@ import {
 } from "../../../redux/selectors";
 import styled from "@emotion/styled/macro";
 import {API_URL} from "../../../utilities/constants";
-import {useParams, useNavigate} from "react-router-dom";
+import {useParams, useNavigate, useSearchParams} from "react-router-dom";
 
 const ErrorContainer = styled.div`
 	margin-top: 0.3rem;
@@ -25,23 +25,33 @@ const DropdownSelect = styled.select`
 function TrainingViewNameInput() {
   const storePageInfo = useSelector(getTrainingPageInfo);
   const [pageTitle, setPageTitle] = useState(storePageInfo.title);
-  const [viewersInput, setViewersInput] = useState("everyone");
+  const [viewersInput, setViewersInput] = useState(storePageInfo.viewers || "everyone");
   const [error, setError] = useState("");
   const [description, setDescription] = useState(storePageInfo.description);
   const trainingPageItems = useSelector(getTrainingPageItems);
   const {pageId, category} = useParams();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const trainingPageId = searchParams.get("trainingPageId");
   const [showAlert, setShowAlert] = useState(true);
   const handleFormSubmit = async e => {
-    alert("Done saving training page");
-    setError("");
     e.preventDefault();
+    setError("");
     if (!pageTitle) {
       setError("Please enter a training path name");
       return;
     }
     if (!trainingPageItems.length) {
       setError("Please select at least one training item");
+      return;
+    }
+    // a reload wipes the store, so saving would overwrite the page with stale
+    // defaults (e.g. silently downgrading viewers from internal to everyone)
+    if (trainingPageId && !storePageInfo.title) {
+      setError(
+        "The training page data is no longer loaded. Reopen it with the " +
+        "Edit button on the training page before saving."
+      );
       return;
     }
 
@@ -57,21 +67,37 @@ function TrainingViewNameInput() {
     console.log("reqbody before posting: ", reqBody);
 
     try {
-      const response = await (
-        await fetch(`${API_URL}/training`, {
-          method: "POST",
+      const response = await fetch(
+        trainingPageId ? `${API_URL}/training/${trainingPageId}` : `${API_URL}/training`,
+        {
+          method: trainingPageId ? "PATCH" : "POST",
           credentials: "include",
           headers: {
             "Content-Type": "application/json"
           },
           body: JSON.stringify(reqBody)
-        })
-      ).json();
-      const newUrl = `/training/${response.id}`;
+        }
+      );
+      const responseBody = await response.json();
+      if (!response.ok) {
+        const validationErrors = responseBody.errors
+          ? responseBody.errors.map(validationError => validationError.msg).join(" ")
+          : "";
+        setError(
+          validationErrors ||
+          responseBody.error ||
+          "Unable to save the training page. Please try again."
+        );
+        return;
+      }
+
+      alert("Done saving training page");
+      const newUrl = `/training/${responseBody.id}`;
       navigate(newUrl);
     } catch (err) {
-      console.log(err);
-      throw err;
+      console.error(err);
+      setError("Unable to save the training page. Please try again.");
+      return;
     }
 
     setDescription("");
@@ -118,7 +144,7 @@ function TrainingViewNameInput() {
             </DropdownSelect>
           </div>
           <button type="submit" className="btn btn-primary btn-save">
-  					Save
+            Save
           </button>
         </form>
         {error && <ErrorContainer>{error}</ErrorContainer>}

--- a/client/src/pages/TrainingPage/TrainingPage.js
+++ b/client/src/pages/TrainingPage/TrainingPage.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import React, { useState, useEffect } from 'react'
-import { useParams, Link } from 'react-router-dom'
+import { useParams, useNavigate, Link } from 'react-router-dom'
 import styled from '@emotion/styled/macro'
 import { API_URL, MODE, ROLE } from '../../utilities/constants'
 import LoadingOverlay from '../../components/General/LoadingOverlay'
@@ -53,6 +53,7 @@ function TrainingPage() {
 	const [error, setError] = useState('')
 	const { role } = getProfile()
 	const dispatch = useDispatch()
+	const navigate = useNavigate()
 	// fetch initial data of the entire page
 	const fetchData = async () => {
 		const response = await (
@@ -74,7 +75,8 @@ function TrainingPage() {
 					items: allItems,
 					info: {
 						title: response.pageTitle,
-						description: response.description
+						description: response.description,
+						viewers: response.viewers
 					}
 				})
 			)
@@ -100,7 +102,6 @@ function TrainingPage() {
 
 	const handleEditBtnClicked = e => {
 		setMode(MODE.CREATE_TRAINING)
-		window.localStorage.setItem('trainingPageId', pageContent.pageId)
 	}
 
 	const handleSourceBtnClicked = e => {
@@ -110,14 +111,34 @@ function TrainingPage() {
 	}
 
 	const handleDelete = async e => {
-		alert('Training page deleted. Redirecting to wiki page')
-		const response = await (
-			await fetch(`${API_URL}/training/${pageId}`, {
+		// navigate only once the delete is confirmed by the API
+		e.preventDefault()
+		try {
+			const response = await fetch(`${API_URL}/training/${pageId}`, {
 				method: 'DELETE',
 				credentials: 'include',
 				headers: { 'Content-Type': 'application/json' }
 			})
-		).json()
+			const responseBody = await response.json()
+			if (!response.ok) {
+				const validationErrors = responseBody.errors
+					? responseBody.errors.map(validationError => validationError.msg).join(' ')
+					: ''
+				alert(
+					validationErrors ||
+						responseBody.error ||
+						'Unable to delete this training page.'
+				)
+				return
+			}
+			alert('Training page deleted. Redirecting to wiki page')
+			// clear the store so create-training mode does not prefill the deleted page
+			dispatch(resetTrainingPage())
+			navigate(SOURCE_PAGE_PATH)
+		} catch (err) {
+			console.error(err)
+			alert('Unable to delete this training page. Please try again.')
+		}
 	}
 
 	useEffect(() => {
@@ -159,7 +180,7 @@ function TrainingPage() {
 								Original Page
 							</SourceBtn>
 							<EditBtn
-								to={SOURCE_PAGE_PATH}
+								to={`${SOURCE_PAGE_PATH}?trainingPageId=${pageContent.pageId}`}
 								className="btn btn-primary"
 								onClick={handleEditBtnClicked}
 							>

--- a/models/trainingPages.js
+++ b/models/trainingPages.js
@@ -1,31 +1,99 @@
 const {pool} = require("../services/database/mysqlPool");
 
+// insert every item of a training page with a single bulk statement
+async function insertTrainingPageItems(connection, pageId, itemList) {
+  if (!itemList.length) {
+    return;
+  }
+
+  const query = "INSERT INTO TrainingPageItems " +
+    "(trainingPageId, itemId, annotation) VALUES ?";
+  // validation allows a missing or null annotation, both of which store as NULL
+  const rows = itemList.map(item => [
+    pageId,
+    item.id,
+    typeof item.annotation === "string" ? item.annotation : null
+  ]);
+
+  await connection.query(query, [rows]);
+}
+
 async function createTrainingPage(itemList, name, description, viewers, sourcePageId, category) {
-  // insert name to TrainingPages table in database
-  const insertPageQuery = `INSERT INTO TrainingPages (name, description, viewers, category, sourcePageId) VALUES (?, ?, ?, ?, ?)`;
-  const insertPageItemsQuery = `INSERT INTO TrainingPageItems (trainingPageId, itemId, annotation) VALUES (?, ?, ?)`;
-  const removePageQuery = `DELETE from TrainingPages WHERE name=?`;
+  const insertPageQuery = "INSERT INTO TrainingPages " +
+    "(name, description, viewers, category, sourcePageId) " +
+    "VALUES (?, ?, ?, ?, ?)";
   const capitalizedCategory = category.charAt(0).toUpperCase() + category.slice(1);
-  let insertResult;
+  const connection = await pool.getConnection();
+  let transactionStarted = false;
 
   try {
-    // remove existing entries from both tables before insert
-    await pool.query(removePageQuery, [name]);
-
-    insertResult = await pool.query(insertPageQuery, [name, description, viewers, capitalizedCategory, sourcePageId]);
-    const pageId = insertResult[0].insertId;
-
-    // traverse the itemList and build the query array
-    const queryList = itemList.map(item =>
-      pool.query(insertPageItemsQuery, [pageId, item.id, item.annotation])
-    );
-    await Promise.all(queryList);
+    await connection.beginTransaction();
+    transactionStarted = true;
+    const [insertResult] = await connection.query(insertPageQuery, [
+      name,
+      description,
+      viewers,
+      capitalizedCategory,
+      sourcePageId
+    ]);
+    const pageId = insertResult.insertId;
+    await insertTrainingPageItems(connection, pageId, itemList);
+    await connection.commit();
+    return {id: pageId};
   } catch (err) {
-    return {error: err};
+    if (transactionStarted) {
+      await connection.rollback();
+    }
+    throw err;
+  } finally {
+    connection.release();
   }
-  return insertResult[0];
 }
 module.exports.createTrainingPage = createTrainingPage;
+
+async function updateTrainingPage(pageId, itemList, name, description, viewers, sourcePageId, category) {
+  const getPageQuery = "SELECT id FROM TrainingPages WHERE id = ? FOR UPDATE";
+  const updatePageQuery = "UPDATE TrainingPages SET name = ?, description = ?, " +
+    "viewers = ?, category = ?, sourcePageId = ? WHERE id = ?";
+  const deletePageItemsQuery = "DELETE FROM TrainingPageItems WHERE trainingPageId = ?";
+  const capitalizedCategory = category.charAt(0).toUpperCase() + category.slice(1);
+  const connection = await pool.getConnection();
+  let transactionStarted = false;
+
+  try {
+    await connection.beginTransaction();
+    transactionStarted = true;
+    const [[page]] = await connection.query(getPageQuery, [pageId]);
+
+    if (!page) {
+      await connection.rollback();
+      transactionStarted = false;
+      return null;
+    }
+
+    await connection.query(updatePageQuery, [
+      name,
+      description,
+      viewers,
+      capitalizedCategory,
+      sourcePageId,
+      pageId
+    ]);
+    await connection.query(deletePageItemsQuery, [pageId]);
+    await insertTrainingPageItems(connection, pageId, itemList);
+    await connection.commit();
+
+    return {id: parseInt(pageId, 10)};
+  } catch (err) {
+    if (transactionStarted) {
+      await connection.rollback();
+    }
+    throw err;
+  } finally {
+    connection.release();
+  }
+}
+module.exports.updateTrainingPage = updateTrainingPage;
 
 async function getTrainingPage(pageId) {
   const result = {pageId: parseInt(pageId)};
@@ -138,5 +206,3 @@ module.exports.deleteTrainingPage = async function (pageId) {
   const [results] = await pool.query(query, [pageId]);
   return results;
 };
-
-

--- a/routes/trainingPages.js
+++ b/routes/trainingPages.js
@@ -1,60 +1,139 @@
 const express = require("express");
 const app = express.Router();
 
+const {validationResult} = require("express-validator");
+const {
+  requireAuth,
+  getUserID,
+  roleCheck,
+  internalCheck
+} = require("../services/authentication/cookieAuth");
+const {
+  postTrainingPageVal,
+  patchTrainingPageVal,
+  deleteTrainingPageVal
+} = require("../services/validation/requestValidation");
 const {
   createTrainingPage,
+  updateTrainingPage,
   getTrainingPagesFromSourcePage,
   getTrainingPage,
   deleteTrainingPage
 } = require("../models/trainingPages");
 
-app.post("/", async (req, res) => {
-  // create new entry in TrainingPages in database
+// keep only the fields the model writes, so unexpected body fields are dropped
+function normalizedTrainingPage(req) {
+  return {
+    itemList: req.body.itemList.map(item => ({
+      id: item.id,
+      annotation: item.annotation
+    })),
+    name: req.body.name,
+    // description is optional; mysql2 rejects undefined bind parameters
+    description: req.body.description === undefined ? null : req.body.description,
+    viewers: req.body.viewers,
+    sourcePageId: req.body.sourcePageId,
+    category: req.body.category
+  };
+}
 
-  const itemList = req.body.itemList;
-  const name = req.body.name;
-  const description = req.body.description;
-  const sourcePageId = req.body.sourcePageId;
-  const category = req.body.category;
-  const viewers = req.body.viewers;
-  // validate ids and name
-  const response = await createTrainingPage(
-    itemList,
-    name,
-    description,
-    viewers,
-    sourcePageId,
-    category
-  );
+// respond with 422 and report if the request failed validation
+function invalidRequest(req, res) {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    console.error(errors.array());
+    res.status(422).json({errors: errors.array()});
+    return true;
+  }
+  return false;
+}
 
-  // if there's an error, then there's an error code
-  if (response.error) {
-    res.status(400).json(response);
-  } else {
-    console.log(response);
-    // if no error, response 201
+// translate database errors from a create or update into a client response
+function writeError(err, res, action) {
+  if (err && err.code === "ER_DUP_ENTRY") {
+    return res.status(409).json({
+      error: action === "update"
+        ? "Another training page with this name already exists. Pick a " +
+          "different name."
+        : "A training page with this name already exists. Use the edit " +
+          "button on that training page to update it, or pick a different name."
+    });
+  }
+  if (err && (err.code === "ER_NO_REFERENCED_ROW" || err.code === "ER_NO_REFERENCED_ROW_2")) {
+    return res.status(400).json({
+      error: "Unknown source page, category, or training item."
+    });
+  }
+  console.error(err);
+  return res.status(500).json({
+    error: "An internal server error occurred. Please try again later."
+  });
+}
+
+app.post("/", requireAuth, postTrainingPageVal.validation, async (req, res) => {
+  try {
+    if (invalidRequest(req, res)) {
+      return;
+    }
+    if (!await roleCheck(3, req.auth.userId)) {
+      return res.status(401).json({
+        error: "Unauthorized user attempting to create training page."
+      });
+    }
+
+    const page = normalizedTrainingPage(req);
+    if (page.viewers === "internal" && !await internalCheck(req.auth.userId)) {
+      return res.status(403).json({
+        error: "This user is not allowed to create internal training pages."
+      });
+    }
+
+    const response = await createTrainingPage(
+      page.itemList,
+      page.name,
+      page.description,
+      page.viewers,
+      page.sourcePageId,
+      page.category
+    );
+
     res.status(201).json({
-      id: response.insertId,
+      id: response.id,
       message: "OK"
+    });
+  } catch (err) {
+    writeError(err, res);
+  }
+});
+
+app.get("/:pageId", getUserID, async (req, res) => {
+  try {
+    const response = await getTrainingPage(req.params.pageId);
+    if (response.error) {
+      return res.status(400).json(response);
+    }
+    if (response.viewers === "internal" && !await internalCheck(req.auth.userId)) {
+      return res.status(403).json({
+        error: "This training page is only available to internal users."
+      });
+    }
+    res.status(200).json(response);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({
+      error: "An internal server error occurred. Please try again later."
     });
   }
 });
 
-app.get("/:pageId", async (req, res) => {
-  const response = await getTrainingPage(req.params.pageId);
-  // console.log("route, res: ", response);
-  if (response.error) {
-    res.status(400).json(response);
-  } else {
-    res.status(200).json(response);
-  }
-});
-
-app.get("/source-page/:sourcePageId", async (req, res) => {
+app.get("/source-page/:sourcePageId", getUserID, async (req, res) => {
   try {
-    const response = await getTrainingPagesFromSourcePage(
+    let response = await getTrainingPagesFromSourcePage(
       req.params.sourcePageId
     );
+    if (!await internalCheck(req.auth.userId)) {
+      response = response.filter(page => page.viewers !== "internal");
+    }
     res.status(200).json(response);
   } catch (err) {
     console.error(err);
@@ -65,20 +144,67 @@ app.get("/source-page/:sourcePageId", async (req, res) => {
   }
 });
 
-app.delete("/:pageId", async (req, res) => {
+app.patch("/:pageId", requireAuth, patchTrainingPageVal.validation, async (req, res) => {
   try {
+    if (invalidRequest(req, res)) {
+      return;
+    }
+    // editing an existing training page is admin-only, so an external editor
+    // cannot flip an internal page to everyone; no internalCheck is needed
+    if (!await roleCheck(5, req.auth.userId)) {
+      return res.status(401).json({
+        error: "Unauthorized user attempting to update training page."
+      });
+    }
 
-    await deleteTrainingPage(req.params.pageId);
+    const page = normalizedTrainingPage(req);
+    const response = await updateTrainingPage(
+      req.params.pageId,
+      page.itemList,
+      page.name,
+      page.description,
+      page.viewers,
+      page.sourcePageId,
+      page.category
+    );
+
+    if (!response) {
+      return res.status(404).json({error: "Training page not found."});
+    }
+
+    res.status(200).json({
+      id: response.id,
+      message: "OK"
+    });
+  } catch (err) {
+    writeError(err, res, "update");
+  }
+});
+
+app.delete("/:pageId", requireAuth, deleteTrainingPageVal.validation, async (req, res) => {
+  try {
+    if (invalidRequest(req, res)) {
+      return;
+    }
+    if (!await roleCheck(5, req.auth.userId)) {
+      return res.status(401).json({
+        error: "Unauthorized user attempting to delete training page."
+      });
+    }
+    const results = await deleteTrainingPage(req.params.pageId);
+    if (!results.affectedRows) {
+      return res.status(404).json({error: "Training page not found."});
+    }
+
     res.status(201).json({
       message: "OK"
     });
   } catch (err) {
-    console.log(err);
-    res.status(400).json({
-      error: "invalid request"
+    console.error(err);
+    res.status(500).json({
+      error: "An internal server error occurred. Please try again later."
     });
   }
-
 });
 
 module.exports = app;

--- a/services/validation/requestValidation.js
+++ b/services/validation/requestValidation.js
@@ -75,6 +75,83 @@ const getPageVal = Object.freeze({
 });
 exports.getPageVal = getPageVal;
 
+// the largest item count a single training page may contain
+const MAX_TRAINING_ITEMS = 500;
+
+// shared body checks for creating and updating a training page
+function trainingPageBodyValidation() {
+  return [
+    check("name")
+      .isString()
+      .withMessage("Training path name is required.")
+      .bail()
+      .trim()
+      .isLength({min: 1, max: 255})
+      .withMessage("Training path name must be between 1 and 255 characters."),
+    check("description")
+      .optional({nullable: true})
+      .isString()
+      .withMessage("Training path description must be text.")
+      .bail()
+      .custom(value => Buffer.byteLength(value, "utf8") <= 65535)
+      .withMessage("Training path description is too long."),
+    check("viewers")
+      .isIn(["everyone", "internal"])
+      .withMessage("Viewers must be either everyone or internal."),
+    check("category")
+      .isString()
+      .withMessage("Category is required.")
+      .bail()
+      .trim()
+      .isLength({min: 1, max: 255})
+      .withMessage("Category must be between 1 and 255 characters."),
+    check("sourcePageId")
+      .isInt({min: 1, max: 4294967295})
+      .withMessage("Source page ID must be a positive integer."),
+    check("itemList")
+      .isArray({min: 1, max: MAX_TRAINING_ITEMS})
+      .withMessage(`Select between 1 and ${MAX_TRAINING_ITEMS} training items.`)
+      .bail()
+      .custom(itemList => {
+        const itemIds = itemList.map(item => item && item.id);
+        return itemIds.length === new Set(itemIds.map(String)).size;
+      })
+      .withMessage("The same training item cannot be added twice."),
+    check("itemList.*.id")
+      .isInt({min: 1, max: 4294967295})
+      .withMessage("Every training item needs a valid item ID."),
+    check("itemList.*.annotation")
+      .optional({nullable: true})
+      .isString()
+      .withMessage("Annotations must be text.")
+      .bail()
+      .isLength({max: 255})
+      .withMessage("Annotations are limited to 255 characters.")
+  ];
+}
+
+const postTrainingPageVal = Object.freeze({
+  validation: trainingPageBodyValidation()
+});
+exports.postTrainingPageVal = postTrainingPageVal;
+
+const patchTrainingPageVal = Object.freeze({
+  validation: [
+    check("pageId").isInt({min: 1, max: 4294967295})
+      .withMessage("Training page ID must be a positive integer."),
+    ...trainingPageBodyValidation()
+  ]
+});
+exports.patchTrainingPageVal = patchTrainingPageVal;
+
+const deleteTrainingPageVal = Object.freeze({
+  validation: [
+    check("pageId").isInt({min: 1, max: 4294967295})
+      .withMessage("Training page ID must be a positive integer.")
+  ]
+});
+exports.deleteTrainingPageVal = deleteTrainingPageVal;
+
 // validation checks for search user
 const searchPageVal = Object.freeze({
   validation: [


### PR DESCRIPTION
## Summary

- require role 3 or higher to create training pages
- require role 5 to update or delete training pages
- split creation from updates so edits use `PATCH /api/training/:pageId`
- validate requests before persistence and perform multi-step writes in transactions
- keep intended public reads available while enforcing visibility for internal training pages
- surface rejected saves and deletes in the client without reporting success prematurely

## Root cause

The training router was mounted without authentication or authorization on its write endpoints. In addition, `POST /api/training` doubled as an overwrite operation: it deleted an existing page by name before validating and inserting the replacement. An anonymous malformed request could therefore delete a training page even when the request ultimately returned an error.

This change makes POST create-only, moves updates to an authorized PATCH route, and wraps page/item persistence in transactions so failed writes do not leave destructive partial state.

## Validation

- focused Playwright regression spec: 1 passed
- targeted backend and client ESLint
- containerized client production build
- `git diff --check dev...HEAD`
- manual contract check: role-3 PATCH is rejected, DELETE still returns 201, and anonymous GET remains intentionally public

Resolves #144
