### PR TITLE
chore: consolidate compatible dependency updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@
 // Description: handles server functions and setup
 
 // setup database connection and routing
-require("dotenv").config({silent: process.env.NODE_ENV === "production"});
+require("dotenv").config({quiet: process.env.NODE_ENV === "production"});
 
 const express = require("express");
 const path = require("path");

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5579,9 +5579,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -8436,9 +8436,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"funding": [
 				{
 					"type": "github",
@@ -8541,9 +8541,9 @@
 			}
 		},
 		"node_modules/filelist/node_modules/brace-expansion": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+			"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0"
@@ -21927,9 +21927,9 @@
 			"requires": {}
 		},
 		"brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -23820,9 +23820,9 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="
 		},
 		"fast-uri": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="
 		},
 		"fastq": {
 			"version": "1.20.1",
@@ -23886,9 +23886,9 @@
 			},
 			"dependencies": {
 				"brace-expansion": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-					"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+					"integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
 					"requires": {
 						"balanced-match": "^1.0.0"
 					}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
 				"moment": "^2.27.0",
 				"morgan": "~1.11.0",
 				"multer": "^2.2.0",
-				"mysql2": "^3.23.1",
+				"mysql2": "^3.23.2",
 				"react-quill": "^2.0.0",
 				"sanitize-html": "^2.17.6",
 				"validator": "^13.15.35"
@@ -3504,9 +3504,9 @@
 			}
 		},
 		"node_modules/mysql2": {
-			"version": "3.23.1",
-			"resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.1.tgz",
-			"integrity": "sha512-tTuRnC7qCet2IOfSNMYZ5SwXuBnfvBPAcIA28P0gtruXyZlU1LMxA6uha32kYypoFgyYklMqhLWwt4laYwXR/Q==",
+			"version": "3.23.2",
+			"resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.23.2.tgz",
+			"integrity": "sha512-fxh3HpQ8vJtu/Mmnd4Xsur19jGjHGzRLMxptiDtOkbX7EVBgnafGSGDx1WGGVmJLClVh2LeeBMMo24IFv8wCyQ==",
 			"license": "MIT",
 			"dependencies": {
 				"aws-ssl-profiles": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -630,9 +630,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -2091,9 +2091,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"funding": [
 				{
 					"type": "github",
@@ -3603,9 +3603,9 @@
 			}
 		},
 		"node_modules/nodemon/node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"dotenv": "^17.4.2",
 				"eslint": "^7.25.0",
 				"express": "^5.2.1",
-				"express-validator": "^6.5.0",
+				"express-validator": "^7.3.2",
 				"jsonwebtoken": "^9.0.3",
 				"moment": "^2.27.0",
 				"morgan": "~1.11.0",
@@ -1929,13 +1929,13 @@
 			}
 		},
 		"node_modules/express-validator": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.15.0.tgz",
-			"integrity": "sha512-r05VYoBL3i2pswuehoFSy+uM8NBuVaY7avp5qrYjQBDzagx2Z5A77FZqPT8/gNLF3HopWkIzaTFaC4JysWXLqg==",
+			"version": "7.3.2",
+			"resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.3.2.tgz",
+			"integrity": "sha512-ctLw1Vl6dXVH62dIQMDdTAQkrh480mkFuG6/SGXOaVlwPNukhRAe7EgJIMJ2TSAni8iwHBRp530zAZE5ZPF2IA==",
 			"license": "MIT",
 			"dependencies": {
-				"lodash": "^4.17.21",
-				"validator": "^13.9.0"
+				"lodash": "^4.18.1",
+				"validator": "~13.15.23"
 			},
 			"engines": {
 				"node": ">= 8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"cookie": "^0.7.2",
 				"cookie-parser": "~1.4.4",
 				"cross-env": "^7.0.2",
-				"dotenv": "^8.2.0",
+				"dotenv": "^17.4.2",
 				"eslint": "^7.25.0",
 				"express": "^5.2.1",
 				"express-validator": "^6.5.0",
@@ -1241,12 +1241,15 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-			"integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
 			"license": "BSD-2-Clause",
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"node_modules/dunder-proto": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"cookie": "^0.7.2",
 				"cookie-parser": "~1.4.4",
 				"cross-env": "^7.0.2",
-				"debug": "~2.6.9",
 				"dotenv": "^8.2.0",
 				"eslint": "^7.25.0",
 				"express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"dotenv": "^17.4.2",
 		"eslint": "^7.25.0",
 		"express": "^5.2.1",
-		"express-validator": "^6.5.0",
+		"express-validator": "^7.3.2",
 		"jsonwebtoken": "^9.0.3",
 		"moment": "^2.27.0",
 		"morgan": "~1.11.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"cookie": "^0.7.2",
 		"cookie-parser": "~1.4.4",
 		"cross-env": "^7.0.2",
-		"dotenv": "^8.2.0",
+		"dotenv": "^17.4.2",
 		"eslint": "^7.25.0",
 		"express": "^5.2.1",
 		"express-validator": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"moment": "^2.27.0",
 		"morgan": "~1.11.0",
 		"multer": "^2.2.0",
-		"mysql2": "^3.23.1",
+		"mysql2": "^3.23.2",
 		"react-quill": "^2.0.0",
 		"sanitize-html": "^2.17.6",
 		"validator": "^13.15.35"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
 		"cookie": "^0.7.2",
 		"cookie-parser": "~1.4.4",
 		"cross-env": "^7.0.2",
-		"debug": "~2.6.9",
 		"dotenv": "^8.2.0",
 		"eslint": "^7.25.0",
 		"express": "^5.2.1",

--- a/routes/banners.js
+++ b/routes/banners.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express.Router();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getBanners,
   createBanners

--- a/routes/cards.js
+++ b/routes/cards.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express.Router();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   roleCheck,
   internalCheck,

--- a/routes/categories.js
+++ b/routes/categories.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {formatAlphanumeric} = require("../services/format/formatAlphanumeric");
 const {
   roleCheck,

--- a/routes/contributors.js
+++ b/routes/contributors.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express.Router();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getContributors,
   getPendingContributors,

--- a/routes/curators.js
+++ b/routes/curators.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getPageCurators,
   getCurators,

--- a/routes/files.js
+++ b/routes/files.js
@@ -6,7 +6,7 @@ const express = require("express");
 const crypto = require("crypto");
 const fs = require("fs");
 const app = express();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   requireAuth,
   roleCheck

--- a/routes/headers.js
+++ b/routes/headers.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express.Router();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   roleCheck,
   internalCheck,

--- a/routes/home.js
+++ b/routes/home.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   roleCheck,
   requireAuth,

--- a/routes/icons.js
+++ b/routes/icons.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express.Router();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getIcons,
   updateIcon,

--- a/routes/info.js
+++ b/routes/info.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express.Router();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getInfo,
   updateInfo

--- a/routes/links.js
+++ b/routes/links.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express.Router();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getLinks,
   updateLink,

--- a/routes/pages.js
+++ b/routes/pages.js
@@ -4,7 +4,7 @@
 const express = require("express");
 const app = express();
 
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   roleCheck,
   internalCheck,

--- a/routes/quizzes.js
+++ b/routes/quizzes.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getUserID,
   requireAuth,

--- a/routes/requests.js
+++ b/routes/requests.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express.Router();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getRequests,
   getRequest,

--- a/routes/sources.js
+++ b/routes/sources.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express.Router();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getSources,
   createSources,

--- a/routes/trainingPages.js
+++ b/routes/trainingPages.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const app = express.Router();
 
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   requireAuth,
   getUserID,

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   roleCheck,
   requireAuth,

--- a/routes/views.js
+++ b/routes/views.js
@@ -3,7 +3,7 @@
 
 const express = require("express");
 const app = express();
-const {validationResult} = require("express-validator");
+const {validationResult} = require("../services/validation/validationResult");
 const {
   getUserID,
   requireAuth,

--- a/services/validation/validationResult.js
+++ b/services/validation/validationResult.js
@@ -1,0 +1,17 @@
+// File: validationResult.js
+// Description: Preserves the API's validation error response format
+
+const {validationResult} = require("express-validator");
+
+function formatValidationError(error) {
+  return {
+    value: error.value,
+    msg: error.msg,
+    param: error.path,
+    location: error.location
+  };
+}
+
+exports.validationResult = validationResult.withDefaults({
+  formatter: formatValidationError
+});


### PR DESCRIPTION
## Summary

- remove the unused direct `debug` dependency while preserving transitive consumers
- update `mysql2` to 3.23.2 and `dotenv` to 17.4.2, using dotenv's supported `quiet` option
- update `express-validator` to 7.3.2 and preserve the existing `{ value, msg, param, location }` API error contract through one shared formatter
- refresh root and client lockfiles to secure `brace-expansion` and `fast-uri` resolutions

## Dependency disposition

- replaces the compatible work formerly proposed by #147, #150, #151, #152, and #153
- defers Node 25 from #146; production and development remain on Node 24 LTS
- defers ESLint 10 from #149 to a separate flat-config migration
- excludes the CI-only #148 login-action update
- leaves #104 untouched

The Dependabot PRs are already closed and unmerged.

## Validation

- fresh root and client `npm ci --legacy-peer-deps`
- root audit improved from 7 to 5 findings, with high severity decreasing 4 to 2
- client audit improved from 31 to 29 findings, with high severity decreasing 17 to 15
- changed JavaScript files pass ESLint; `git diff --check` passes
- production-equivalent client build and production Docker image build pass on Node 24
- isolated MariaDB smoke checks and mysql2 create/read/update/delete checks pass
- local Playwright suite passes 26/26, including the merged #145 authorization matrix and exact legacy validation-error keys

The local Playwright harness is untracked. Its temporary validation copy corrected two stale #145 expectations to match merged behavior: trimmed duplicate names return 409, and anonymous reads of internal pages return 403. The original harness was not modified.

## Baseline notes

- the repository has no committed Jest tests; the committed test command passes with `--passWithNoTests`
- broad legacy lint findings and existing peer/tree warnings reproduce unchanged from `origin/dev`
- the repository's actual PR build path, the production Dockerfile, passes
