### PR TITLE
test: add client Vitest foundation

### DIFF
--- a/.github/workflows/client-tests.yml
+++ b/.github/workflows/client-tests.yml
@@ -1,0 +1,27 @@
+name: Client tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  vitest:
+    name: vitest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+      - run: npm ci --ignore-scripts
+      - run: npm test

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,8 @@
 		"deploy": "gh-pages -d build",
 		"start": "vite",
 		"build": "vite build",
-		"test": "vitest run"
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"devDependencies": {
 		"@testing-library/jest-dom": "^6.1.5",

--- a/client/src/components/General/RichTextEditor.test.js
+++ b/client/src/components/General/RichTextEditor.test.js
@@ -1,0 +1,60 @@
+// Unit test for RichTextEditor (react-quill wrapper).
+// Fast, isolated guard that react-quill 2.0.0 integrates under React 18 + jsdom:
+// the component mounts a Quill editor without throwing, honors the showToolbar()
+// theme switch, and passes the placeholder through. Deep editing behavior
+// (typing, formatting, formula, save round-trip) is covered by the Playwright
+// e2e specs against a real browser, where Quill's contenteditable actually
+// works; jsdom cannot faithfully drive that, so this stays at the mount/wiring
+// level on purpose.
+import React from "react";
+import {render} from "@testing-library/react";
+
+Object.defineProperty(document, "execCommand", {
+  configurable: true,
+  value: vi.fn(() => false)
+});
+Object.defineProperty(document, "queryCommandSupported", {
+  configurable: true,
+  value: vi.fn(() => false)
+});
+
+const {default: RichTextEditor} = await import("./RichTextEditor");
+
+const baseProps = {
+  id: "unit-test",
+  value: "",
+  onChange: () => {},
+  placeHolder: "Enter text",
+};
+
+test("mounts a Quill editor without crashing under React 18", () => {
+  const {container} = render(<RichTextEditor {...baseProps} showToolbar={() => true} />);
+  // Quill's contenteditable surface. If react-quill 2.0.0 failed to mount under
+  // React 18, this node would be absent.
+  expect(container.querySelector(".ql-editor")).toBeInTheDocument();
+});
+
+test("showToolbar() true renders the snow theme with a toolbar", () => {
+  const {container} = render(<RichTextEditor {...baseProps} showToolbar={() => true} />);
+  expect(container.querySelector(".ql-container.ql-snow")).toBeInTheDocument();
+  expect(container.querySelector(".ql-toolbar.ql-snow")).toBeInTheDocument();
+  // Toolbar mode drops the plain-border wrapper class.
+  expect(container.querySelector(".text-editor")).not.toHaveClass("simple-text-border");
+});
+
+test("showToolbar() false keeps the snow editor mounted but flags the hidden toolbar", () => {
+  const {container} = render(<RichTextEditor {...baseProps} showToolbar={() => false} />);
+  // Theme stays snow (never bubble) so selection never rebuilds the editor.
+  expect(container.querySelector(".ql-container.ql-snow")).toBeInTheDocument();
+  expect(container.querySelector(".ql-container.ql-bubble")).not.toBeInTheDocument();
+  // Wrapper flags the hidden-toolbar state; CSS collapses the toolbar.
+  expect(container.querySelector(".text-editor")).toHaveClass("simple-text-border");
+  expect(container.querySelector(".text-editor")).toHaveClass("hide-toolbar");
+});
+
+test("passes the placeholder through to Quill", () => {
+  render(<RichTextEditor {...baseProps} placeHolder="Enter text" showToolbar={() => true} />);
+  // Quill mirrors the placeholder onto the editor's data-placeholder attribute.
+  const editor = document.querySelector(".ql-editor");
+  expect(editor).toHaveAttribute("data-placeholder", "Enter text");
+});

--- a/client/src/components/General/Sanitized.test.js
+++ b/client/src/components/General/Sanitized.test.js
@@ -1,0 +1,40 @@
+import React from "react";
+import {render, screen} from "@testing-library/react";
+import Sanitized from "./Sanitized";
+
+test("removes scripts and event handlers while retaining visible content", () => {
+  const {container} = render(
+    <Sanitized html={'<div><script>alert("unsafe")</script><button onclick="alert(1)">Safe content</button></div>'} />
+  );
+
+  expect(screen.getByRole("button", {name: "Safe content"})).not.toHaveAttribute("onclick");
+  expect(container.querySelector("script")).not.toBeInTheDocument();
+});
+
+test("removes unsafe URLs", () => {
+  render(<Sanitized html={'<a href="javascript:alert(1)">Unsafe link</a>'} />);
+
+  expect(screen.getByText("Unsafe link")).not.toHaveAttribute("href");
+});
+
+test("filters classes and styles to the intentional rich-text allowlist", () => {
+  const {container} = render(
+    <Sanitized html={'<span class="ql-size-large injected" style="color:#123456; background-image:url(javascript:alert(1))">Styled text</span>'} />
+  );
+  const content = screen.getByText("Styled text");
+
+  expect(content).toHaveClass("ql-size-large");
+  expect(content).not.toHaveClass("injected");
+  expect(content).toHaveStyle({color: "rgb(18, 52, 86)"});
+  expect(content.style.backgroundImage).toBe("");
+  expect(container.querySelector("[class~='injected']")).not.toBeInTheDocument();
+});
+
+test("preserves intentional Quill and KaTeX MathML markup", () => {
+  const html = '<div><p class="ql-size-huge">Formula <span class="ql-formula katex" data-value="x^2"><span class="katex-mathml"><math><semantics><mrow><msup><mi>x</mi><mn>2</mn></msup></mrow><annotation encoding="application/x-tex">x^2</annotation></semantics></math></span></span></p></div>';
+  const {container} = render(<Sanitized html={html} />);
+
+  expect(screen.getByText("Formula", {exact: false})).toHaveClass("ql-size-huge");
+  expect(container.querySelector(".ql-formula.katex .katex-mathml math msup")).not.toBeNull();
+  expect(container.querySelector("annotation")?.textContent).toBe("x^2");
+});

--- a/client/src/redux/reducer.test.js
+++ b/client/src/redux/reducer.test.js
@@ -1,0 +1,79 @@
+import {
+  addTrainingItem,
+  populateTrainingPage,
+  removeTrainingItem,
+  resetTrainingPage
+} from "./actions";
+import rootReducer from "./reducer";
+import {
+  getTrainingPageContent,
+  getTrainingPageInfo,
+  getTrainingPageItems
+} from "./selectors";
+
+test("provides the initial training-page state", () => {
+  expect(rootReducer(undefined, {type: "unknown"})).toEqual({
+    trainingPageItems: [],
+    trainingPageInfo: {title: "", description: ""}
+  });
+});
+
+test("adds a training item", () => {
+  const item = {id: 1, type: "text", value: "First"};
+
+  expect(rootReducer(undefined, addTrainingItem(item)).trainingPageItems).toEqual([item]);
+});
+
+test("deduplicates and updates training items by ID", () => {
+  const state = {
+    trainingPageItems: [{id: 1, value: "Old"}, {id: 2, value: "Other"}],
+    trainingPageInfo: {title: "Training", description: "Description"}
+  };
+  const replacement = {id: 1, value: "Updated"};
+
+  expect(rootReducer(state, addTrainingItem(replacement)).trainingPageItems).toEqual([
+    {id: 2, value: "Other"},
+    replacement
+  ]);
+});
+
+test("removes a training item by ID", () => {
+  const state = {
+    trainingPageItems: [{id: 1}, {id: 2}],
+    trainingPageInfo: {title: "", description: ""}
+  };
+
+  expect(rootReducer(state, removeTrainingItem({id: "1"})).trainingPageItems).toEqual([{id: 2}]);
+});
+
+test("populates training items and page information together", () => {
+  const payload = {
+    items: [{id: 3, value: "Loaded"}],
+    info: {title: "Loaded training", description: "Loaded description"}
+  };
+
+  expect(rootReducer(undefined, populateTrainingPage(payload))).toEqual({
+    trainingPageItems: payload.items,
+    trainingPageInfo: payload.info
+  });
+});
+
+test("resets the training items", () => {
+  const state = {
+    trainingPageItems: [{id: 1}],
+    trainingPageInfo: {title: "Training", description: "Description"}
+  };
+
+  expect(rootReducer(state, resetTrainingPage()).trainingPageItems).toEqual([]);
+});
+
+test("selects items, information, and complete training-page content", () => {
+  const state = {
+    trainingPageItems: [{id: 1}],
+    trainingPageInfo: {title: "Training", description: "Description"}
+  };
+
+  expect(getTrainingPageItems(state)).toBe(state.trainingPageItems);
+  expect(getTrainingPageInfo(state)).toBe(state.trainingPageInfo);
+  expect(getTrainingPageContent(state)).toBe(state);
+});

--- a/client/src/test/setup.js
+++ b/client/src/test/setup.js
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/client/src/utilities/cookieAuth.test.js
+++ b/client/src/utilities/cookieAuth.test.js
@@ -1,0 +1,56 @@
+import {changeUsername, getProfile, loggedIn, logout} from "./cookieAuth";
+
+const cookieNames = ["userId_ck", "username_ck", "role_ck"];
+
+function clearAuthCookies() {
+  cookieNames.forEach(name => {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+  });
+}
+
+function setAuthCookies({userId = "42", username = "alex", role = "3"} = {}) {
+  document.cookie = `userId_ck=${userId}; path=/;`;
+  document.cookie = `username_ck=${username}; path=/;`;
+  document.cookie = `role_ck=${role}; path=/;`;
+}
+
+beforeEach(clearAuthCookies);
+afterEach(clearAuthCookies);
+
+test("parses a valid user profile", () => {
+  setAuthCookies();
+
+  expect(getProfile()).toEqual({username: "alex", userId: 42, role: 3});
+});
+
+test("falls back to the logged-out profile for missing or malformed cookies", () => {
+  const loggedOutProfile = {username: "", userId: 0, role: 0};
+  expect(getProfile()).toEqual(loggedOutProfile);
+
+  setAuthCookies({role: "editor"});
+  expect(getProfile()).toEqual(loggedOutProfile);
+});
+
+test("reports whether the current cookie profile is logged in", () => {
+  expect(loggedIn()).toBe(false);
+
+  setAuthCookies();
+  expect(loggedIn()).toBe(true);
+});
+
+test("changes the username without changing the remaining profile", () => {
+  setAuthCookies();
+
+  changeUsername("casey");
+
+  expect(getProfile()).toEqual({username: "casey", userId: 42, role: 3});
+});
+
+test("logs out by clearing all authentication cookies", () => {
+  setAuthCookies();
+
+  logout();
+
+  expect(getProfile()).toEqual({username: "", userId: 0, role: 0});
+  cookieNames.forEach(name => expect(document.cookie).not.toContain(`${name}=`));
+});

--- a/client/src/utilities/formatRelativeTime.test.js
+++ b/client/src/utilities/formatRelativeTime.test.js
@@ -1,0 +1,33 @@
+import {
+  MS_PER_SECOND,
+  MS_PER_MINUTE,
+  MS_PER_HOUR,
+  MS_PER_DAY,
+  MS_PER_MONTH,
+  MS_PER_YEAR
+} from "./constants";
+import {formatRelativeTime} from "./formatRelativeTime";
+
+const now = new Date("2026-01-15T12:00:00.000Z");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(now);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test.each([
+  ["one second", MS_PER_SECOND, "1 second ago"],
+  ["two minutes", 2 * MS_PER_MINUTE, "2 minutes ago"],
+  ["one hour", MS_PER_HOUR, "1 hour ago"],
+  ["one day", MS_PER_DAY, "1 day ago"],
+  ["two months", 2 * MS_PER_MONTH, "2 months ago"],
+  ["one year", MS_PER_YEAR, "1 year ago"]
+])("formats an unaffected %s timestamp", (_label, elapsed, expected) => {
+  const timestamp = new Date(now.getTime() - elapsed).toISOString();
+
+  expect(formatRelativeTime(timestamp)).toBe(expected);
+});

--- a/client/src/utilities/isExternalImageUrl.test.js
+++ b/client/src/utilities/isExternalImageUrl.test.js
@@ -1,0 +1,19 @@
+import {isExternalImageUrl} from "./isExternalImageUrl";
+
+test("treats empty and local paths as internal", () => {
+  ["", "/uploads/example.png", "images/example.png"].forEach(url => {
+    expect(isExternalImageUrl(url)).toBe(false);
+  });
+});
+
+test("recognizes protocol-relative and HTTP URLs as external", () => {
+  ["//cdn.example.com/image.png", "http://example.com/image.png", "https://example.com/image.png"].forEach(url => {
+    expect(isExternalImageUrl(url)).toBe(true);
+  });
+});
+
+test("recognizes other URL schemes as external", () => {
+  ["data:image/png;base64,abc", "blob:https://example.com/id", "ftp://example.com/image.png"].forEach(url => {
+    expect(isExternalImageUrl(url)).toBe(true);
+  });
+});

--- a/client/src/utilities/modes.test.js
+++ b/client/src/utilities/modes.test.js
@@ -1,0 +1,49 @@
+import {getProfile} from "./cookieAuth";
+import {getMode} from "./pageMode";
+import {getPublic} from "./publicMode";
+import {getPublished} from "./publishedMode";
+
+vi.mock("./cookieAuth", () => ({
+  getProfile: vi.fn()
+}));
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+test("role thresholds override stored modes", () => {
+  window.localStorage.setItem("pageMode", "2");
+  window.localStorage.setItem("publicMode", "0");
+  window.localStorage.setItem("publishedMode", "1");
+
+  getProfile.mockReturnValue({role: 1});
+  expect(getMode()).toBe(0);
+  expect(getPublic()).toBe(1);
+
+  getProfile.mockReturnValue({role: 3});
+  expect(getPublished()).toBe(0);
+});
+
+test("page mode uses its default and stored values for editors", () => {
+  getProfile.mockReturnValue({role: 2});
+  expect(getMode()).toBe(0);
+
+  window.localStorage.setItem("pageMode", "2");
+  expect(getMode()).toBe(2);
+});
+
+test("public mode uses its default and stored values for editors", () => {
+  getProfile.mockReturnValue({role: 2});
+  expect(getPublic()).toBe(0);
+
+  window.localStorage.setItem("publicMode", "1");
+  expect(getPublic()).toBe(1);
+});
+
+test("published mode uses its default and stored values for administrators", () => {
+  getProfile.mockReturnValue({role: 4});
+  expect(getPublished()).toBe(0);
+
+  window.localStorage.setItem("publishedMode", "1");
+  expect(getPublished()).toBe(1);
+});

--- a/client/src/utilities/normalizeRichText.test.js
+++ b/client/src/utilities/normalizeRichText.test.js
@@ -1,0 +1,24 @@
+import {normalizeEmptyRichText} from "./normalizeRichText";
+
+test("normalizes empty paragraph, break, and non-breaking-space markup", () => {
+  [
+    "",
+    "<p></p>",
+    "<p><br></p>",
+    "<p>&nbsp;</p>",
+    "<p> <br /> &nbsp; </p>"
+  ].forEach(value => expect(normalizeEmptyRichText(value)).toBe(""));
+});
+
+test("preserves the original rich text when content remains", () => {
+  const value = "<p>Hello<br>world</p>";
+
+  expect(normalizeEmptyRichText(value)).toBe(value);
+});
+
+test("passes non-string values through unchanged", () => {
+  const objectValue = {html: "<p></p>"};
+
+  expect(normalizeEmptyRichText(null)).toBeNull();
+  expect(normalizeEmptyRichText(objectValue)).toBe(objectValue);
+});

--- a/client/vite.config.mjs
+++ b/client/vite.config.mjs
@@ -78,7 +78,10 @@ export default defineConfig(({command, mode}) => {
     },
     test: {
       environment: "jsdom",
-      globals: true
+      globals: true,
+      setupFiles: "./src/test/setup.js",
+      clearMocks: true,
+      restoreMocks: true
     }
   };
 });


### PR DESCRIPTION
## Summary

- add a shared Vitest setup with jest-dom matchers and automatic mock cleanup
- add eight colocated suites covering rich text, sanitization, client utilities, modes, cookies, relative time, and Redux state
- add `npm run test:watch` while retaining `npm test` as the CI run command
- add the `Client tests / vitest` check for pull requests and pushes to `dev`

## Why

The Vite migration already provides Vitest, jsdom, globals, and the required testing dependencies. This stacked change turns that wiring into a focused client test foundation without changing runtime behavior, backend code, or the local Playwright harness.

This PR is stacked on #158 and intentionally targets `feat/vite-migration`. After the parent merges, the child branch can be retargeted or replayed onto `dev` depending on the merge strategy.

## Validation

- `cd client && npm ci --ignore-scripts`
- `cd client && npm test` — 8 suites, 36 tests passed
- `cd client && npm run build`
- `git diff --check`

No console-warning suppression was added; ReactQuill compatibility warnings remain non-fatal. The production build still reports its existing bundle-size advisory.
