### PR TITLE
chore: replace ReactQuill with react-quill-new

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -2004,6 +2004,18 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@jridgewell/source-map": {
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
+			}
+		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -2438,6 +2450,27 @@
 				"tslib": "^2.8.0"
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"picocolors": "1.1.1",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@testing-library/jest-dom": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2598,7 +2631,7 @@
 			"version": "18.3.7",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
@@ -2851,6 +2884,20 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -3166,6 +3213,14 @@
 			"peerDependencies": {
 				"browserslist": "*"
 			}
+		},
+		"node_modules/buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
@@ -3949,6 +4004,12 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/fast-diff": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -5904,6 +5965,20 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/quill-delta": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+			"integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-diff": "^1.3.0",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.isequal": "^4.5.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6039,12 +6114,6 @@
 				"react-dom": "^16 || ^17 || ^18 || ^19"
 			}
 		},
-		"node_modules/react-quill-new/node_modules/fast-diff": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/react-quill-new/node_modules/parchment": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
@@ -6064,20 +6133,6 @@
 			},
 			"engines": {
 				"npm": ">=8.2.3"
-			}
-		},
-		"node_modules/react-quill-new/node_modules/quill-delta": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-			"integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
-			"license": "MIT",
-			"dependencies": {
-				"fast-diff": "^1.3.0",
-				"lodash.clonedeep": "^4.5.0",
-				"lodash.isequal": "^4.5.0"
-			},
-			"engines": {
-				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/react-redux": {
@@ -6722,6 +6777,29 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			}
+		},
+		"node_modules/source-map-support/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6840,6 +6918,34 @@
 			"integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/terser": {
+			"version": "5.50.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+			"integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.15.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"bin": {
+				"terser": "bin/terser"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/terser/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
@@ -7981,7 +8087,8 @@
 			"version": "7.21.0-placeholder-for-preset-env.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
 			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@babel/plugin-syntax-import-assertions": {
 			"version": "7.29.7",
@@ -8648,7 +8755,8 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
 			"integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@csstools/css-color-parser": {
 			"version": "4.1.10",
@@ -8664,13 +8772,15 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
 			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@csstools/css-syntax-patches-for-csstree": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
 			"integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@csstools/css-tokenizer": {
 			"version": "4.0.0",
@@ -8779,7 +8889,8 @@
 		"@emotion/use-insertion-effect-with-fallbacks": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg=="
+			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
+			"requires": {}
 		},
 		"@emotion/utils": {
 			"version": "1.4.2",
@@ -8795,12 +8906,14 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
 			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@icons/material": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
+			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+			"requires": {}
 		},
 		"@jridgewell/gen-mapping": {
 			"version": "0.3.13",
@@ -8825,6 +8938,17 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
+		},
+		"@jridgewell/source-map": {
+			"version": "0.3.11",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25"
+			}
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
@@ -8933,7 +9057,8 @@
 				"uncontrollable": {
 					"version": "8.0.4",
 					"resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
-					"integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ=="
+					"integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+					"requires": {}
 				}
 			}
 		},
@@ -9059,6 +9184,23 @@
 				"tslib": "^2.8.0"
 			}
 		},
+		"@testing-library/dom": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"picocolors": "1.1.1",
+				"pretty-format": "^27.0.2"
+			}
+		},
 		"@testing-library/jest-dom": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -9123,7 +9265,8 @@
 			"version": "14.6.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
 			"integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"@types/aria-query": {
 			"version": "5.0.4",
@@ -9184,12 +9327,14 @@
 			"version": "18.3.7",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-			"dev": true
+			"devOptional": true,
+			"requires": {}
 		},
 		"@types/react-transition-group": {
 			"version": "4.4.12",
 			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-			"integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w=="
+			"integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+			"requires": {}
 		},
 		"@types/trusted-types": {
 			"version": "2.0.7",
@@ -9358,6 +9503,13 @@
 				"negotiator": "0.6.3"
 			}
 		},
+		"acorn": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+			"dev": true,
+			"peer": true
+		},
 		"agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -9523,7 +9675,8 @@
 		"bootstrap": {
 			"version": "5.3.8",
 			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-			"integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg=="
+			"integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+			"requires": {}
 		},
 		"braces": {
 			"version": "3.0.3",
@@ -9555,6 +9708,13 @@
 			"requires": {
 				"meow": "^13.0.0"
 			}
+		},
+		"buffer-from": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
+			"peer": true
 		},
 		"bytes": {
 			"version": "3.1.2",
@@ -10098,6 +10258,11 @@
 					"dev": true
 				}
 			}
+		},
+		"fast-diff": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
 		},
 		"fast-glob": {
 			"version": "3.3.3",
@@ -11280,6 +11445,16 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
+		"quill-delta": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+			"integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+			"requires": {
+				"fast-diff": "^1.3.0",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.isequal": "^4.5.0"
+			}
+		},
 		"range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -11352,7 +11527,8 @@
 		"react-icons": {
 			"version": "4.12.0",
 			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-			"integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw=="
+			"integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
+			"requires": {}
 		},
 		"react-is": {
 			"version": "16.13.1",
@@ -11373,11 +11549,6 @@
 				"quill": "~2.0.3"
 			},
 			"dependencies": {
-				"fast-diff": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-					"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
-				},
 				"parchment": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
@@ -11392,16 +11563,6 @@
 						"lodash-es": "^4.17.21",
 						"parchment": "^3.0.0",
 						"quill-delta": "^5.1.0"
-					}
-				},
-				"quill-delta": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-					"integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
-					"requires": {
-						"fast-diff": "^1.3.0",
-						"lodash.clonedeep": "^4.5.0",
-						"lodash.isequal": "^4.5.0"
 					}
 				}
 			}
@@ -11487,7 +11648,8 @@
 		"redux-thunk": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-			"integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="
+			"integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+			"requires": {}
 		},
 		"regenerate": {
 			"version": "1.4.2",
@@ -11824,6 +11986,26 @@
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"dev": true
 		},
+		"source-map-support": {
+			"version": "0.5.21",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"buffer-from": "^1.0.0",
+				"source-map": "^0.6.0"
+			},
+			"dependencies": {
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
+					"peer": true
+				}
+			}
+		},
 		"stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -11909,6 +12091,28 @@
 			"integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
 			"dev": true
 		},
+		"terser": {
+			"version": "5.50.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
+			"integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@jridgewell/source-map": "^0.3.3",
+				"acorn": "^8.15.0",
+				"commander": "^2.20.0",
+				"source-map-support": "~0.5.20"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true,
+					"peer": true
+				}
+			}
+		},
 		"tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -11940,7 +12144,8 @@
 					"version": "6.5.0",
 					"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
 					"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-					"dev": true
+					"dev": true,
+					"requires": {}
 				},
 				"picomatch": {
 					"version": "4.0.5",
@@ -12100,7 +12305,8 @@
 		"use-sync-external-store": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"requires": {}
 		},
 		"utils-merge": {
 			"version": "1.0.1",
@@ -12290,7 +12496,8 @@
 			"version": "8.21.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
 			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
-			"dev": true
+			"dev": true,
+			"requires": {}
 		},
 		"xml-name-validator": {
 			"version": "5.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,7 +21,7 @@
 				"react-color": "^2.17.2",
 				"react-dom": "^18.3.1",
 				"react-icons": "^4.2.0",
-				"react-quill": "^2.0.0",
+				"react-quill-new": "^3.8.3",
 				"react-redux": "^8.1.0",
 				"react-router-dom": "^7.18.1",
 				"validator": "^13.15.35"
@@ -2004,18 +2004,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@jridgewell/source-map": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -2450,27 +2438,6 @@
 				"tslib": "^2.8.0"
 			}
 		},
-		"node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@testing-library/jest-dom": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2617,15 +2584,6 @@
 			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
 			"license": "MIT"
 		},
-		"node_modules/@types/quill": {
-			"version": "1.3.10",
-			"resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
-			"integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
-			"license": "MIT",
-			"dependencies": {
-				"parchment": "^1.1.2"
-			}
-		},
 		"node_modules/@types/react": {
 			"version": "18.3.27",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
@@ -2640,7 +2598,7 @@
 			"version": "18.3.7",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
@@ -2893,20 +2851,6 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/acorn": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -3223,14 +3167,6 @@
 				"browserslist": "*"
 			}
 		},
-		"node_modules/buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
-		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3245,6 +3181,7 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
 			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -3263,6 +3200,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
@@ -3276,6 +3214,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -3366,15 +3305,6 @@
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
 			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
 			"license": "MIT"
-		},
-		"node_modules/clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8"
-			}
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
@@ -3659,6 +3589,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0",
@@ -3676,6 +3607,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
 			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.0.1",
@@ -3778,6 +3710,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.1",
@@ -3832,6 +3765,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
 			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -3841,6 +3775,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -3878,6 +3813,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
 			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0"
@@ -3934,6 +3870,12 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"license": "MIT"
 		},
 		"node_modules/expect-type": {
 			"version": "1.4.0",
@@ -4007,18 +3949,6 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"license": "MIT"
-		},
-		"node_modules/fast-diff": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-			"license": "Apache-2.0"
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
@@ -4241,6 +4171,7 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
 			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -4260,6 +4191,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.2",
@@ -4284,6 +4216,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
@@ -4354,6 +4287,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
 			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -4396,6 +4330,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0"
@@ -4408,6 +4343,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
 			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -4420,6 +4356,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-symbols": "^1.0.3"
@@ -4617,6 +4554,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
 			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -4718,6 +4656,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
 			"integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -4804,6 +4743,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
 			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.2",
@@ -5323,11 +5263,24 @@
 			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"license": "MIT"
 		},
+		"node_modules/lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+			"license": "MIT"
+		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+			"deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
 			"license": "MIT"
 		},
 		"node_modules/loose-envify": {
@@ -5398,6 +5351,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
 			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -5586,6 +5540,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
 			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.7",
@@ -5602,6 +5557,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -5693,12 +5649,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/parchment": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-			"integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
@@ -5954,80 +5904,6 @@
 			],
 			"license": "MIT"
 		},
-		"node_modules/quill": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-			"integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"clone": "^2.1.1",
-				"deep-equal": "^1.0.1",
-				"eventemitter3": "^2.0.3",
-				"extend": "^3.0.2",
-				"parchment": "^1.1.4",
-				"quill-delta": "^3.6.2"
-			}
-		},
-		"node_modules/quill-delta": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-			"integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
-			"license": "MIT",
-			"dependencies": {
-				"deep-equal": "^1.0.1",
-				"extend": "^3.0.2",
-				"fast-diff": "1.1.2"
-			},
-			"engines": {
-				"node": ">=0.10"
-			}
-		},
-		"node_modules/quill-delta/node_modules/deep-equal": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-			"integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-arguments": "^1.1.1",
-				"is-date-object": "^1.0.5",
-				"is-regex": "^1.1.4",
-				"object-is": "^1.1.5",
-				"object-keys": "^1.1.1",
-				"regexp.prototype.flags": "^1.5.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/quill/node_modules/deep-equal": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-			"integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-arguments": "^1.1.1",
-				"is-date-object": "^1.0.5",
-				"is-regex": "^1.1.4",
-				"object-is": "^1.1.5",
-				"object-keys": "^1.1.1",
-				"regexp.prototype.flags": "^1.5.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/quill/node_modules/eventemitter3": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-			"integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==",
-			"license": "MIT"
-		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6148,19 +6024,60 @@
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
 			"license": "MIT"
 		},
-		"node_modules/react-quill": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
-			"integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+		"node_modules/react-quill-new": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.8.3.tgz",
+			"integrity": "sha512-c96PYqFTo0pI4R3e79B3rH9LUIce1kIQbmTBu/imJQZk8305ogyLyBqKKjG2UoInDlquXqePSzmBo2aVia3ttw==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/quill": "^1.3.10",
-				"lodash": "^4.17.4",
-				"quill": "^1.3.7"
+				"lodash-es": "^4.17.21",
+				"quill": "~2.0.3"
 			},
 			"peerDependencies": {
-				"react": "^16 || ^17 || ^18",
-				"react-dom": "^16 || ^17 || ^18"
+				"quill-delta": "^5.1.0",
+				"react": "^16 || ^17 || ^18 || ^19",
+				"react-dom": "^16 || ^17 || ^18 || ^19"
+			}
+		},
+		"node_modules/react-quill-new/node_modules/fast-diff": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/react-quill-new/node_modules/parchment": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+			"integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/react-quill-new/node_modules/quill": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+			"integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"eventemitter3": "^5.0.1",
+				"lodash-es": "^4.17.21",
+				"parchment": "^3.0.0",
+				"quill-delta": "^5.1.0"
+			},
+			"engines": {
+				"npm": ">=8.2.3"
+			}
+		},
+		"node_modules/react-quill-new/node_modules/quill-delta": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+			"integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-diff": "^1.3.0",
+				"lodash.clonedeep": "^4.5.0",
+				"lodash.isequal": "^4.5.0"
+			},
+			"engines": {
+				"node": ">= 12.0.0"
 			}
 		},
 		"node_modules/react-redux": {
@@ -6344,6 +6261,7 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
 			"integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind": "^1.0.8",
@@ -6657,6 +6575,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.1.4",
@@ -6674,6 +6593,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
 			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.1.4",
@@ -6802,29 +6722,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/source-map-support/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -6943,34 +6840,6 @@
 			"integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/terser": {
-			"version": "5.50.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
-			"integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"peer": true,
-			"dependencies": {
-				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.15.0",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			},
-			"bin": {
-				"terser": "bin/terser"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/terser/node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
@@ -8112,8 +7981,7 @@
 			"version": "7.21.0-placeholder-for-preset-env.2",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
 			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@babel/plugin-syntax-import-assertions": {
 			"version": "7.29.7",
@@ -8780,8 +8648,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
 			"integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/css-color-parser": {
 			"version": "4.1.10",
@@ -8797,15 +8664,13 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
 			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/css-syntax-patches-for-csstree": {
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
 			"integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@csstools/css-tokenizer": {
 			"version": "4.0.0",
@@ -8914,8 +8779,7 @@
 		"@emotion/use-insertion-effect-with-fallbacks": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
-			"requires": {}
+			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg=="
 		},
 		"@emotion/utils": {
 			"version": "1.4.2",
@@ -8931,14 +8795,12 @@
 			"version": "1.15.1",
 			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
 			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@icons/material": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
-			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-			"requires": {}
+			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
 		},
 		"@jridgewell/gen-mapping": {
 			"version": "0.3.13",
@@ -8963,17 +8825,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
-		},
-		"@jridgewell/source-map": {
-			"version": "0.3.11",
-			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-			"integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25"
-			}
 		},
 		"@jridgewell/sourcemap-codec": {
 			"version": "1.5.5",
@@ -9082,8 +8933,7 @@
 				"uncontrollable": {
 					"version": "8.0.4",
 					"resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
-					"integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
-					"requires": {}
+					"integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ=="
 				}
 			}
 		},
@@ -9209,23 +9059,6 @@
 				"tslib": "^2.8.0"
 			}
 		},
-		"@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
-			}
-		},
 		"@testing-library/jest-dom": {
 			"version": "6.9.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -9290,8 +9123,7 @@
 			"version": "14.6.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
 			"integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@types/aria-query": {
 			"version": "5.0.4",
@@ -9339,14 +9171,6 @@
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
 			"integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw=="
 		},
-		"@types/quill": {
-			"version": "1.3.10",
-			"resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
-			"integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
-			"requires": {
-				"parchment": "^1.1.2"
-			}
-		},
 		"@types/react": {
 			"version": "18.3.27",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
@@ -9360,14 +9184,12 @@
 			"version": "18.3.7",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-			"devOptional": true,
-			"requires": {}
+			"dev": true
 		},
 		"@types/react-transition-group": {
 			"version": "4.4.12",
 			"resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-			"integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-			"requires": {}
+			"integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w=="
 		},
 		"@types/trusted-types": {
 			"version": "2.0.7",
@@ -9536,13 +9358,6 @@
 				"negotiator": "0.6.3"
 			}
 		},
-		"acorn": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
-			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
-			"dev": true,
-			"peer": true
-		},
 		"agent-base": {
 			"version": "7.1.4",
 			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -9708,8 +9523,7 @@
 		"bootstrap": {
 			"version": "5.3.8",
 			"resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-			"integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
-			"requires": {}
+			"integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg=="
 		},
 		"braces": {
 			"version": "3.0.3",
@@ -9742,13 +9556,6 @@
 				"meow": "^13.0.0"
 			}
 		},
-		"buffer-from": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-			"dev": true,
-			"peer": true
-		},
 		"bytes": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -9759,6 +9566,7 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
 			"integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+			"dev": true,
 			"requires": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
@@ -9770,6 +9578,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
 			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
 			"requires": {
 				"es-errors": "^1.3.0",
 				"function-bind": "^1.1.2"
@@ -9779,6 +9588,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
 			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"dev": true,
 			"requires": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"get-intrinsic": "^1.3.0"
@@ -9826,11 +9636,6 @@
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
 			"integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
-		},
-		"clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
 		},
 		"color-convert": {
 			"version": "2.0.1",
@@ -10033,6 +9838,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
 			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"dev": true,
 			"requires": {
 				"es-define-property": "^1.0.0",
 				"es-errors": "^1.3.0",
@@ -10043,6 +9849,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
 			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+			"dev": true,
 			"requires": {
 				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
@@ -10113,6 +9920,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
 			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
 			"requires": {
 				"call-bind-apply-helpers": "^1.0.1",
 				"es-errors": "^1.3.0",
@@ -10154,12 +9962,14 @@
 		"es-define-property": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true
 		},
 		"es-errors": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true
 		},
 		"es-get-iterator": {
 			"version": "1.1.3",
@@ -10188,6 +9998,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
 			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"dev": true,
 			"requires": {
 				"es-errors": "^1.3.0"
 			}
@@ -10220,6 +10031,11 @@
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
 			"dev": true
+		},
+		"eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
 		},
 		"expect-type": {
 			"version": "1.4.0",
@@ -10282,16 +10098,6 @@
 					"dev": true
 				}
 			}
-		},
-		"extend": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-		},
-		"fast-diff": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-			"integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
 		},
 		"fast-glob": {
 			"version": "3.3.3",
@@ -10446,7 +10252,8 @@
 		"functions-have-names": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+			"dev": true
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -10458,6 +10265,7 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
 			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
 			"requires": {
 				"call-bind-apply-helpers": "^1.0.2",
 				"es-define-property": "^1.0.1",
@@ -10475,6 +10283,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
 			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
 			"requires": {
 				"dunder-proto": "^1.0.1",
 				"es-object-atoms": "^1.0.0"
@@ -10521,7 +10330,8 @@
 		"gopd": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true
 		},
 		"graceful-fs": {
 			"version": "4.2.11",
@@ -10545,6 +10355,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
 			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"dev": true,
 			"requires": {
 				"es-define-property": "^1.0.0"
 			}
@@ -10552,12 +10363,14 @@
 		"has-symbols": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true
 		},
 		"has-tostringtag": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
 			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.3"
 			}
@@ -10690,6 +10503,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
 			"integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+			"dev": true,
 			"requires": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
@@ -10748,6 +10562,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
 			"integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+			"dev": true,
 			"requires": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
@@ -10800,6 +10615,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
 			"integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+			"dev": true,
 			"requires": {
 				"call-bound": "^1.0.2",
 				"gopd": "^1.2.0",
@@ -11060,11 +10876,21 @@
 			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
 			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
 		},
+		"lodash.clonedeep": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+			"integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+		},
 		"lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
 		},
 		"loose-envify": {
 			"version": "1.4.0",
@@ -11115,7 +10941,8 @@
 		"math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true
 		},
 		"media-typer": {
 			"version": "0.3.0",
@@ -11222,6 +11049,7 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
 			"integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1"
@@ -11230,7 +11058,8 @@
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"dev": true
 		},
 		"object.assign": {
 			"version": "4.1.7",
@@ -11284,11 +11113,6 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 			"dev": true
-		},
-		"parchment": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
-			"integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
 		},
 		"parent-module": {
 			"version": "1.0.1",
@@ -11456,64 +11280,6 @@
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true
 		},
-		"quill": {
-			"version": "1.3.7",
-			"resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
-			"integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
-			"requires": {
-				"clone": "^2.1.1",
-				"deep-equal": "^1.0.1",
-				"eventemitter3": "^2.0.3",
-				"extend": "^3.0.2",
-				"parchment": "^1.1.4",
-				"quill-delta": "^3.6.2"
-			},
-			"dependencies": {
-				"deep-equal": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-					"integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-					"requires": {
-						"is-arguments": "^1.1.1",
-						"is-date-object": "^1.0.5",
-						"is-regex": "^1.1.4",
-						"object-is": "^1.1.5",
-						"object-keys": "^1.1.1",
-						"regexp.prototype.flags": "^1.5.1"
-					}
-				},
-				"eventemitter3": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
-					"integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
-				}
-			}
-		},
-		"quill-delta": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
-			"integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
-			"requires": {
-				"deep-equal": "^1.0.1",
-				"extend": "^3.0.2",
-				"fast-diff": "1.1.2"
-			},
-			"dependencies": {
-				"deep-equal": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
-					"integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
-					"requires": {
-						"is-arguments": "^1.1.1",
-						"is-date-object": "^1.0.5",
-						"is-regex": "^1.1.4",
-						"object-is": "^1.1.5",
-						"object-keys": "^1.1.1",
-						"regexp.prototype.flags": "^1.5.1"
-					}
-				}
-			}
-		},
 		"range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -11586,8 +11352,7 @@
 		"react-icons": {
 			"version": "4.12.0",
 			"resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
-			"integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
-			"requires": {}
+			"integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw=="
 		},
 		"react-is": {
 			"version": "16.13.1",
@@ -11599,14 +11364,46 @@
 			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
 			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
 		},
-		"react-quill": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
-			"integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+		"react-quill-new": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.8.3.tgz",
+			"integrity": "sha512-c96PYqFTo0pI4R3e79B3rH9LUIce1kIQbmTBu/imJQZk8305ogyLyBqKKjG2UoInDlquXqePSzmBo2aVia3ttw==",
 			"requires": {
-				"@types/quill": "^1.3.10",
-				"lodash": "^4.17.4",
-				"quill": "^1.3.7"
+				"lodash-es": "^4.17.21",
+				"quill": "~2.0.3"
+			},
+			"dependencies": {
+				"fast-diff": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+					"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw=="
+				},
+				"parchment": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
+					"integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A=="
+				},
+				"quill": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
+					"integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
+					"requires": {
+						"eventemitter3": "^5.0.1",
+						"lodash-es": "^4.17.21",
+						"parchment": "^3.0.0",
+						"quill-delta": "^5.1.0"
+					}
+				},
+				"quill-delta": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
+					"integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
+					"requires": {
+						"fast-diff": "^1.3.0",
+						"lodash.clonedeep": "^4.5.0",
+						"lodash.isequal": "^4.5.0"
+					}
+				}
 			}
 		},
 		"react-redux": {
@@ -11690,8 +11487,7 @@
 		"redux-thunk": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
-			"integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-			"requires": {}
+			"integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="
 		},
 		"regenerate": {
 			"version": "1.4.2",
@@ -11718,6 +11514,7 @@
 			"version": "1.5.4",
 			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
 			"integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+			"dev": true,
 			"requires": {
 				"call-bind": "^1.0.8",
 				"define-properties": "^1.2.1",
@@ -11928,6 +11725,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
 			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"dev": true,
 			"requires": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -11941,6 +11739,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
 			"integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+			"dev": true,
 			"requires": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -12024,26 +11823,6 @@
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"dev": true
-		},
-		"source-map-support": {
-			"version": "0.5.21",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"stackback": {
 			"version": "0.0.2",
@@ -12130,28 +11909,6 @@
 			"integrity": "sha512-Nk8c4lXvMB98MtbmjX7JwJRgJOL8fluecYCfCeYBznwmpOs8Bf15hLM6z4z71EDAhQVrQrI+wt1aLWSXZq+hXA==",
 			"dev": true
 		},
-		"terser": {
-			"version": "5.50.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
-			"integrity": "sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"@jridgewell/source-map": "^0.3.3",
-				"acorn": "^8.15.0",
-				"commander": "^2.20.0",
-				"source-map-support": "~0.5.20"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"dev": true,
-					"peer": true
-				}
-			}
-		},
 		"tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -12183,8 +11940,7 @@
 					"version": "6.5.0",
 					"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
 					"integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"picomatch": {
 					"version": "4.0.5",
@@ -12344,8 +12100,7 @@
 		"use-sync-external-store": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-			"requires": {}
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="
 		},
 		"utils-merge": {
 			"version": "1.0.1",
@@ -12535,8 +12290,7 @@
 			"version": "8.21.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
 			"integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "5.0.0",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,7 +14,7 @@
 				"bootstrap": "^5.3.8",
 				"cookie": "^0.7.2",
 				"diff-match-patch": "^1.0.5",
-				"dompurify": "^3.4.12",
+				"dompurify": "^3.4.14",
 				"katex": "^0.18.1",
 				"react": "^18.3.1",
 				"react-bootstrap": "^2.10.10",
@@ -23,7 +23,7 @@
 				"react-icons": "^4.2.0",
 				"react-quill-new": "^3.8.3",
 				"react-redux": "^8.1.0",
-				"react-router-dom": "^7.18.1",
+				"react-router-dom": "^7.18.2",
 				"validator": "^13.15.35"
 			},
 			"devDependencies": {
@@ -3753,9 +3753,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.12",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-			"integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+			"version": "3.4.14",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+			"integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -6181,9 +6181,9 @@
 			"license": "MIT"
 		},
 		"node_modules/react-router": {
-			"version": "7.18.1",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-			"integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+			"integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
 			"license": "MIT",
 			"dependencies": {
 				"cookie": "^1.0.1",
@@ -6203,12 +6203,12 @@
 			}
 		},
 		"node_modules/react-router-dom": {
-			"version": "7.18.1",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-			"integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+			"integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
 			"license": "MIT",
 			"dependencies": {
-				"react-router": "7.18.1"
+				"react-router": "7.18.2"
 			},
 			"engines": {
 				"node": ">=20.0.0"
@@ -10069,9 +10069,9 @@
 			}
 		},
 		"dompurify": {
-			"version": "3.4.12",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-			"integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+			"version": "3.4.14",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+			"integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
 			"requires": {
 				"@types/trusted-types": "^2.0.7"
 			}
@@ -11588,9 +11588,9 @@
 			}
 		},
 		"react-router": {
-			"version": "7.18.1",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-			"integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+			"integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
 			"requires": {
 				"cookie": "^1.0.1",
 				"set-cookie-parser": "^2.6.0"
@@ -11604,11 +11604,11 @@
 			}
 		},
 		"react-router-dom": {
-			"version": "7.18.1",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-			"integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+			"integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
 			"requires": {
-				"react-router": "7.18.1"
+				"react-router": "7.18.2"
 			}
 		},
 		"react-transition-group": {

--- a/client/package.json
+++ b/client/package.json
@@ -17,7 +17,7 @@
 		"react-color": "^2.17.2",
 		"react-dom": "^18.3.1",
 		"react-icons": "^4.2.0",
-		"react-quill": "^2.0.0",
+		"react-quill-new": "^3.8.3",
 		"react-redux": "^8.1.0",
 		"react-router-dom": "^7.18.1",
 		"validator": "^13.15.35"

--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
 		"bootstrap": "^5.3.8",
 		"cookie": "^0.7.2",
 		"diff-match-patch": "^1.0.5",
-		"dompurify": "^3.4.12",
+		"dompurify": "^3.4.14",
 		"katex": "^0.18.1",
 		"react": "^18.3.1",
 		"react-bootstrap": "^2.10.10",
@@ -19,7 +19,7 @@
 		"react-icons": "^4.2.0",
 		"react-quill-new": "^3.8.3",
 		"react-redux": "^8.1.0",
-		"react-router-dom": "^7.18.1",
+		"react-router-dom": "^7.18.2",
 		"validator": "^13.15.35"
 	},
 	"scripts": {

--- a/client/src/components/General/RichTextEditor.js
+++ b/client/src/components/General/RichTextEditor.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
-import ReactQuill, {Quill} from "react-quill";
-import "react-quill/dist/quill.snow.css";
-import "react-quill/dist/quill.bubble.css";
+import ReactQuill, {Quill} from "react-quill-new";
+import "react-quill-new/dist/quill.snow.css";
+import "react-quill-new/dist/quill.bubble.css";
 import katex from "katex";
 import "katex/dist/katex.min.css";
 import "./RichTextEditor.css";

--- a/client/src/components/General/RichTextEditor.test.js
+++ b/client/src/components/General/RichTextEditor.test.js
@@ -1,13 +1,14 @@
-// Unit test for RichTextEditor (react-quill wrapper).
-// Fast, isolated guard that react-quill 2.0.0 integrates under React 18 + jsdom:
+// Unit test for RichTextEditor (react-quill-new wrapper).
+// Fast, isolated guard that react-quill-new 3.8.3 integrates under React 18 + jsdom:
 // the component mounts a Quill editor without throwing, honors the showToolbar()
 // theme switch, and passes the placeholder through. Deep editing behavior
 // (typing, formatting, formula, save round-trip) is covered by the Playwright
 // e2e specs against a real browser, where Quill's contenteditable actually
 // works; jsdom cannot faithfully drive that, so this stays at the mount/wiring
 // level on purpose.
+import "@testing-library/jest-dom/vitest";
 import React from "react";
-import {render} from "@testing-library/react";
+import {cleanup, render} from "@testing-library/react";
 
 Object.defineProperty(document, "execCommand", {
   configurable: true,
@@ -20,6 +21,10 @@ Object.defineProperty(document, "queryCommandSupported", {
 
 const {default: RichTextEditor} = await import("./RichTextEditor");
 
+afterEach(() => {
+  cleanup();
+});
+
 const baseProps = {
   id: "unit-test",
   value: "",
@@ -29,7 +34,7 @@ const baseProps = {
 
 test("mounts a Quill editor without crashing under React 18", () => {
   const {container} = render(<RichTextEditor {...baseProps} showToolbar={() => true} />);
-  // Quill's contenteditable surface. If react-quill 2.0.0 failed to mount under
+  // Quill's contenteditable surface. If react-quill-new 3.8.3 failed to mount under
   // React 18, this node would be absent.
   expect(container.querySelector(".ql-editor")).toBeInTheDocument();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -155,6 +155,16 @@
 			"deprecated": "Use @eslint/object-schema instead",
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/@types/node": {
+			"version": "26.3.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
+			"integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~8.3.0"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -611,9 +621,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.16",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+			"version": "1.1.18",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+			"integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -2022,9 +2032,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"version": "3.1.6",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+			"integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -3107,9 +3117,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+			"version": "3.15.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+			"integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^1.0.7",
@@ -3475,15 +3485,16 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -3537,9 +3548,9 @@
 			}
 		},
 		"node_modules/nodemon/node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3890,9 +3901,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.19",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-			"integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+			"version": "8.5.26",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+			"integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3907,8 +3918,9 @@
 					"url": "https://github.com/sponsors/ai"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.17",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -5137,6 +5149,13 @@
 			"integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/undici-types": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/unpipe": {
 			"version": "1.0.0",


### PR DESCRIPTION
## Summary

- Replace `react-quill@2.0.0` / Quill 1.3.7 with `react-quill-new@3.8.3` / Quill 2.0.3.
- Update the editor imports and theme stylesheet paths.
- Preserve the Snow theme, named `Quill` export, size whitelist, formula/KaTeX support, sanitization, hidden-toolbar CSS, and stored HTML behavior.
- Add focused React/Quill mount and wiring coverage without changing the public editor props.

## Stack

This PR is the top layer of GitHub native stack #168: [PR #158](https://github.com/osu-cass/eec-walkthrough-react/pull/158) → [PR #167](https://github.com/osu-cass/eec-walkthrough-react/pull/167) → this PR. GitHub tracks the dependency chain and cascading rebase automatically.

## Validation

- `npm --prefix client test`: 36/36 passed.
- `npm --prefix client run build`: passed.
- Exact child `docker compose build app` with `.env.example`: passed.
- Focused editor Playwright coverage in the validation harness: 11/11 passed, covering mount, formatting, size whitelist, formulas, KaTeX rendering, theme states, and persistence.
- The fresh child worktree could not start its Docker database for a second E2E run because ignored local secret files are intentionally absent; no secrets were copied or modified.

## Audit status

The child lockfile removes the old ReactQuill/Quill 1 dependency chain. The current parent-based client audit still reports inherited DOMPurify and React Router findings plus the known Quill 2.0.3 advisory; this PR does not claim an audit-zero result.